### PR TITLE
feat: prefer GitHub release tarballs for installs

### DIFF
--- a/.github/workflows/sync-plugins.yml
+++ b/.github/workflows/sync-plugins.yml
@@ -30,9 +30,10 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           TURSO_DATABASE_URL: ${{ secrets.TURSO_DATABASE_URL }}
           TURSO_AUTH_TOKEN: ${{ secrets.TURSO_AUTH_TOKEN }}
-      # 探测安装方式：新收录的仓库 + 超过 7 天没探过的重探（作者随时可能发布 npm 或补 prepare）。
-      # 只读 raw.githubusercontent 与 npm registry，不吃 GitHub API 限额。
+      # 探测安装方式：新收录的仓库 + 超过 7 天没探过的重探（作者可能发布 npm、
+      # GitHub Release tarball 或补 prepare）。每个有效 bundle 最多请求一次 Releases API。
       - run: pnpm probe:install
         env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           TURSO_DATABASE_URL: ${{ secrets.TURSO_DATABASE_URL }}
           TURSO_AUTH_TOKEN: ${{ secrets.TURSO_AUTH_TOKEN }}

--- a/messages/en.json
+++ b/messages/en.json
@@ -406,6 +406,7 @@
     "installDerived": "Derived from package metadata",
     "installProfileNote": "The name after --profile is a profile name you choose yourself — swap in whichever one you use.",
     "installGitNote": "The author hasn't published to npm, so this command installs from git source. pnpm ≥ 10 refuses to run a git dependency's prepare script until you grant it, so your first install needs an allowBuilds entry in that profile's pnpm-workspace.yaml — which means letting this package's code run on your machine. Pin a #commit while you're at it.",
+    "installReleaseNote": "This command uses the unique uploaded GitHub Release .tgz whose asset name, release tag, package name, and package version agree. dshfind does not download, unpack, or execute the asset while probing; review the publisher and release before installing.",
     "installBuildTitle": "Requires a manual build",
     "installBuildNote": "This is a bundle, but the author hasn't published to npm, the package entry points at build output (lib/ or dist/), and the repo has no prepare script. Installing straight from git only pulls uncompiled source and the entry won't be there at load time. Build it locally first, then install it by path:",
     "installNoneTitle": "Not an installable plugin package",

--- a/messages/ja.json
+++ b/messages/ja.json
@@ -404,6 +404,7 @@
     "installDerived": "パッケージ情報から推定",
     "installProfileNote": "--profile の後ろは自分で付ける profile 名です。使っているものに置き換えてください。",
     "installGitNote": "作者が npm に公開していないため、このコマンドは git のソースを取得します。pnpm ≥ 10 は git 依存の prepare スクリプトを明示的な許可なしには実行しないので、初回インストールにはその profile の pnpm-workspace.yaml に allowBuilds の記述が必要です——これはこのパッケージのコードを自分のマシンで実行させることを意味します。あわせて #commit で固定することを勧めます。",
+    "installReleaseNote": "このコマンドは、アセット名・Release tag・パッケージ名・バージョンがすべて一致する唯一の GitHub Release .tgz を使用します。dshfind は調査時にアセットをダウンロード、展開、実行しません。インストール前に公開者と Release を確認してください。",
     "installBuildTitle": "自分でビルドが必要",
     "installBuildNote": "これは複合パッケージですが、npm に未公開でパッケージのエントリがビルド成果物（lib/ や dist/）を指しており、リポジトリに prepare スクリプトもありません。git から直接入れても未コンパイルのソースしか取得できず、読み込み時にエントリが見つかりません。まずローカルでビルドし、パスを指定して profile に入れてください：",
     "installNoneTitle": "インストール可能なプラグインパッケージではありません",

--- a/messages/ko.json
+++ b/messages/ko.json
@@ -404,6 +404,7 @@
     "installDerived": "패키지 정보에서 추론",
     "installProfileNote": "--profile 뒤는 직접 정하는 profile 이름입니다. 쓰고 있는 이름으로 바꾸세요.",
     "installGitNote": "작성자가 npm에 배포하지 않아 이 명령은 git 소스를 받아옵니다. pnpm ≥ 10은 명시적 허용 전까지 git 의존성의 prepare 스크립트 실행을 거부하므로, 첫 설치에는 해당 profile의 pnpm-workspace.yaml에 allowBuilds 항목이 필요합니다——이는 이 패키지의 코드가 내 컴퓨터에서 실행되도록 허용한다는 뜻입니다. 함께 #commit으로 버전을 고정하길 권합니다.",
+    "installReleaseNote": "이 명령은 자산 이름, Release tag, 패키지 이름과 버전이 모두 일치하는 유일한 GitHub Release .tgz를 사용합니다. dshfind는 탐지 중 자산을 다운로드하거나 압축 해제 또는 실행하지 않습니다. 설치 전에 게시자와 Release를 확인하세요.",
     "installBuildTitle": "직접 빌드해야 합니다",
     "installBuildNote": "복합 패키지이지만 작성자가 npm에 배포하지 않았고, 패키지 진입점이 빌드 산출물(lib/ 또는 dist/)을 가리키며 저장소에 prepare 스크립트도 없습니다. git에서 바로 설치하면 컴파일되지 않은 소스만 받아 와 로드 시 진입점을 찾지 못합니다. 먼저 로컬에서 빌드한 뒤 경로로 profile에 설치하세요:",
     "installNoneTitle": "설치할 수 있는 플러그인 패키지가 아닙니다",

--- a/messages/zh.json
+++ b/messages/zh.json
@@ -404,6 +404,7 @@
     "installDerived": "按包信息推导",
     "installProfileNote": "--profile 后面是你自己起的 profile 名，换成你在用的那个即可。",
     "installGitNote": "作者尚未发布到 npm，这条命令装的是 git 源码。pnpm ≥ 10 首次安装会拒绝运行 git 依赖的 prepare 脚本，需要你在该 profile 的 pnpm-workspace.yaml 里写 allowBuilds 授权——这等于允许该包的代码在你机器上执行，建议同时用 #commit 锁版本。",
+    "installReleaseNote": "这条命令使用唯一一个资产名、Release tag、包名与包版本完全匹配的 GitHub Release .tgz。dshfind 探测时不会下载、解包或执行该资产；安装前仍应核对发布者与 Release。",
     "installBuildTitle": "需要自行构建",
     "installBuildNote": "这是个组合包，但作者尚未发布到 npm，包入口又指向构建产物（lib/ 或 dist/），仓库也没有 prepare 脚本。git 直装只会拉到未编译的源码，加载时找不到入口。先在本地构建，再按路径装进 profile：",
     "installNoneTitle": "这不是可安装的插件包",

--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
     "build": "next build",
     "start": "next start",
     "lint": "eslint",
+    "test": "node --test scripts/lib/*.test.mjs",
     "gen:plugins": "node --env-file-if-exists=.env.local scripts/gen-plugins-real.mjs",
     "gen:ranking": "node scripts/gen-ranking-real.mjs",
     "gen:data": "pnpm run gen:plugins && pnpm run gen:ranking",

--- a/scripts/lib/github-release-probe.mjs
+++ b/scripts/lib/github-release-probe.mjs
@@ -1,0 +1,108 @@
+import {
+  MAX_RELEASES,
+  selectReleaseTarball,
+} from "./install.mjs";
+
+export const RELEASE_RESPONSE_MAX_BYTES = 1_500_000;
+
+export function noRelease() {
+  return {
+    releaseTgzUrl: null,
+    releaseTag: null,
+    releasePrerelease: false,
+    releaseAssetName: null,
+    releaseAssetSize: null,
+    releaseAssetDigest: null,
+  };
+}
+
+/** 读取有限 JSON；GitHub release body / assets 异常大时直接回退。 */
+async function boundedJson(res, maxBytes) {
+  const declaredHeader = res.headers.get("content-length");
+  const declared = declaredHeader == null ? null : Number(declaredHeader);
+  if (declared != null && Number.isFinite(declared) && declared > maxBytes) {
+    throw new Error(`response too large (${declared} bytes)`);
+  }
+  if (!res.body) throw new Error("empty response body");
+
+  const reader = res.body.getReader();
+  const chunks = [];
+  let total = 0;
+  while (true) {
+    const { done, value } = await reader.read();
+    if (done) break;
+    total += value.byteLength;
+    if (total > maxBytes) {
+      await reader.cancel();
+      throw new Error(`response exceeded ${maxBytes} bytes`);
+    }
+    chunks.push(value);
+  }
+  const bytes = new Uint8Array(total);
+  let offset = 0;
+  for (const chunk of chunks) {
+    bytes.set(chunk, offset);
+    offset += chunk.byteLength;
+  }
+  return JSON.parse(new TextDecoder().decode(bytes));
+}
+
+/**
+ * 最多一次 API 请求、最多 MAX_RELEASES 条，且不下载或解包任何资产。
+ * complete=false 表示 API 不可用：调用方应保留上次成功事实并尽快重试。
+ */
+export async function fetchRelease({
+  fullName,
+  manifest,
+  token,
+  fetchImpl = fetch,
+  warn = console.warn,
+}) {
+  if (!manifest.pkgName || !manifest.pkgVersion || !manifest.hasBundle) {
+    return { complete: true, facts: noRelease() };
+  }
+  try {
+    const headers = {
+      Accept: "application/vnd.github+json",
+      "X-GitHub-Api-Version": "2022-11-28",
+      ...(token ? { Authorization: `Bearer ${token}` } : {}),
+    };
+    const res = await fetchImpl(
+      `https://api.github.com/repos/${fullName}/releases?per_page=${MAX_RELEASES}`,
+      { headers },
+    );
+    const remainingHeader = res.headers.get("x-ratelimit-remaining");
+    const remaining = remainingHeader == null ? null : Number(remainingHeader);
+    if (remaining != null && Number.isFinite(remaining) && remaining < 100) {
+      warn(`  ⚠️ GitHub API 剩余 ${remaining} 次`);
+    }
+    if (!res.ok) {
+      warn(`  ⚠️ ${fullName} releases API ${res.status}，保留上次事实`);
+      return { complete: false, facts: noRelease() };
+    }
+    const releases = await boundedJson(res, RELEASE_RESPONSE_MAX_BYTES);
+    if (!Array.isArray(releases)) throw new Error("releases response is not an array");
+    const selected = selectReleaseTarball({ fullName, ...manifest, releases });
+    return { complete: true, facts: selected ?? noRelease() };
+  } catch (err) {
+    warn(`  ⚠️ ${fullName} release 探测失败：${String(err?.message ?? err)}`);
+    return { complete: false, facts: noRelease() };
+  }
+}
+
+/** API 失败保留旧 release 事实；成功（含“没有匹配资产”）才替换。 */
+export function mergeReleaseProbe({ manifest, npmPublished, release, previousRelease }) {
+  return {
+    facts: {
+      ...manifest,
+      npmPublished,
+      ...(release.complete ? release.facts : previousRelease),
+    },
+    complete: release.complete,
+  };
+}
+
+/** 失败不刷新时间，保证下轮仍会立即重试；rederive 永远不冒充网络探测。 */
+export function probeTimestamp({ rederive, complete, previous, now }) {
+  return rederive || !complete ? previous : now;
+}

--- a/scripts/lib/github-release-probe.test.mjs
+++ b/scripts/lib/github-release-probe.test.mjs
@@ -1,0 +1,87 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import {
+  RELEASE_RESPONSE_MAX_BYTES,
+  fetchRelease,
+  mergeReleaseProbe,
+  noRelease,
+  probeTimestamp,
+} from "./github-release-probe.mjs";
+
+const manifest = {
+  pkgName: "dsh-widget",
+  pkgVersion: "1.2.3",
+  pkgPrivate: false,
+  hasBundle: true,
+  hasPrepare: false,
+  entryNeedsBuild: true,
+};
+
+const previousRelease = {
+  releaseTgzUrl:
+    "https://github.com/example/dsh-widget/releases/download/v1.2.2/dsh-widget-1.2.2.tgz",
+  releaseTag: "v1.2.2",
+  releasePrerelease: false,
+  releaseAssetName: "dsh-widget-1.2.2.tgz",
+  releaseAssetSize: 1_024,
+  releaseAssetDigest: null,
+};
+
+test("HTTP errors are incomplete probes, not evidence that no release exists", async () => {
+  const warnings = [];
+  const result = await fetchRelease({
+    fullName: "example/dsh-widget",
+    manifest,
+    token: "test-token",
+    fetchImpl: async () => new Response("rate limited", { status: 403 }),
+    warn: (message) => warnings.push(message),
+  });
+  assert.equal(result.complete, false);
+  assert.deepEqual(result.facts, noRelease());
+  assert.equal(warnings.length, 1);
+});
+
+test("network errors and oversized metadata are incomplete probes", async () => {
+  for (const fetchImpl of [
+    async () => {
+      throw new Error("offline");
+    },
+    async () =>
+      new Response("[]", {
+        status: 200,
+        headers: { "content-length": String(RELEASE_RESPONSE_MAX_BYTES + 1) },
+      }),
+  ]) {
+    const result = await fetchRelease({
+      fullName: "example/dsh-widget",
+      manifest,
+      token: null,
+      fetchImpl,
+      warn: () => {},
+    });
+    assert.equal(result.complete, false);
+  }
+});
+
+test("an incomplete probe preserves the previous release facts", () => {
+  const merged = mergeReleaseProbe({
+    manifest,
+    npmPublished: true,
+    release: { complete: false, facts: noRelease() },
+    previousRelease,
+  });
+  assert.equal(merged.complete, false);
+  assert.deepEqual(merged.facts, {
+    ...manifest,
+    npmPublished: true,
+    ...previousRelease,
+  });
+});
+
+test("only a complete network probe advances the probe timestamp", () => {
+  const input = { previous: "2026-08-01T00:00:00.000Z", now: "2026-08-15T00:00:00.000Z" };
+  assert.equal(probeTimestamp({ ...input, rederive: false, complete: true }), input.now);
+  assert.equal(probeTimestamp({ ...input, rederive: false, complete: false }), input.previous);
+  assert.equal(probeTimestamp({ ...input, rederive: true, complete: true }), input.previous);
+});

--- a/scripts/lib/install.mjs
+++ b/scripts/lib/install.mjs
@@ -8,17 +8,135 @@
  * 拉的是源码，没有任何环节跑 build，且 pnpm ≥ 10 需要用户在 profile 的 pnpm-workspace.yaml
  * 里显式 allowBuilds 授权才肯运行 prepare。
  *
- * 于是「仓库名」这一个信息根本不足以拼出安装命令，四件事都得先查清楚：
- * 有没有 package.json、是不是组合包、包名叫什么、装完能不能真的加载起来。
+ * 于是「仓库名」这一个信息根本不足以拼出安装命令：manifest、组合包声明、包名/版本、
+ * npm 发布状态与 release 资产都要查清，最后还要判断源码安装能不能加载。
  */
 
 /** 推导结论。null（未探测）由调用方表示，不在此枚举内。 */
 export const INSTALL_KINDS = [
-  "npm", // 已发布 npm，用包名装——首选
+  "release", // GitHub Release 里与包名/版本严格匹配的 tarball
+  "npm", // 没有匹配 release 时，已发布 npm 就用包名装
   "git", // 未发布 npm，但 git 直装能跑起来
   "build-required", // 是组合包，但 git 装拿到的源码缺构建产物，作者也没给 prepare
   "not-installable", // 压根不是可安装的插件包（索引站、文档、独立 App、私有包…）
 ];
+
+/** 单仓库一次最多看这些 release / asset；避免异常仓库放大内存与 CPU 占用。 */
+export const MAX_RELEASES = 10;
+export const MAX_ASSETS_PER_RELEASE = 50;
+export const MAX_RELEASE_ASSET_BYTES = 100 * 1024 * 1024;
+
+const SAFE_PACKAGE_NAME = /^(?:@[a-z0-9][a-z0-9._-]*\/)?[a-z0-9][a-z0-9._-]*$/;
+const SAFE_VERSION = /^(?:0|[1-9]\d*)\.(?:0|[1-9]\d*)\.(?:0|[1-9]\d*)(?:-[0-9A-Za-z-]+(?:\.[0-9A-Za-z-]+)*)?(?:\+[0-9A-Za-z-]+(?:\.[0-9A-Za-z-]+)*)?$/;
+
+function validPackageName(name) {
+  return (
+    typeof name === "string" &&
+    name.length <= 214 &&
+    !name.includes("..") &&
+    SAFE_PACKAGE_NAME.test(name)
+  );
+}
+
+function validVersion(version) {
+  return typeof version === "string" && version.length <= 128 && SAFE_VERSION.test(version);
+}
+
+/** npm pack 对 scoped 包去掉 @ 并用 - 连接 scope/name。 */
+function packedName(pkgName) {
+  return pkgName.startsWith("@") ? pkgName.slice(1).replace("/", "-") : pkgName;
+}
+
+function safeReleaseUrl({ url, fullName, tag, assetName }) {
+  if (typeof url !== "string" || url.length > 2_048) return false;
+  try {
+    const parsed = new URL(url);
+    if (
+      parsed.protocol !== "https:" ||
+      parsed.hostname !== "github.com" ||
+      parsed.port ||
+      parsed.username ||
+      parsed.password ||
+      parsed.search ||
+      parsed.hash
+    ) {
+      return false;
+    }
+    const prefix = `/${fullName}/releases/download/`;
+    if (!parsed.pathname.startsWith(prefix)) return false;
+    const suffix = parsed.pathname.slice(prefix.length);
+    const slash = suffix.lastIndexOf("/");
+    if (slash <= 0) return false;
+    return (
+      decodeURIComponent(suffix.slice(0, slash)) === tag &&
+      decodeURIComponent(suffix.slice(slash + 1)) === assetName
+    );
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * 从 GitHub Releases API 的有限结果里挑唯一可用的版本匹配 tarball。
+ *
+ * 不下载、不解包、更不会执行资产；这里只接受 package.json 的包名/版本、release tag、
+ * prerelease 标记、资产名和 GitHub 下载 URL 全部一致的候选。多个候选时宁可回退。
+ */
+export function selectReleaseTarball({ fullName, pkgName, pkgVersion, releases }) {
+  if (
+    typeof fullName !== "string" ||
+    !/^[A-Za-z0-9_.-]+\/[A-Za-z0-9_.-]+$/.test(fullName) ||
+    !validPackageName(pkgName) ||
+    !validVersion(pkgVersion) ||
+    !Array.isArray(releases)
+  ) {
+    return null;
+  }
+
+  const assetName = `${packedName(pkgName)}-${pkgVersion}.tgz`;
+  const versionIsPrerelease = pkgVersion.split("+")[0].includes("-");
+  const candidates = [];
+
+  for (const release of releases.slice(0, MAX_RELEASES)) {
+    if (!release || release.draft !== false || typeof release.tag_name !== "string") continue;
+    if (release.prerelease !== versionIsPrerelease) continue;
+    const tag = release.tag_name;
+    if (tag !== pkgVersion && tag !== `v${pkgVersion}`) continue;
+    if (!Array.isArray(release.assets)) continue;
+
+    for (const asset of release.assets.slice(0, MAX_ASSETS_PER_RELEASE)) {
+      if (
+        !asset ||
+        asset.state !== "uploaded" ||
+        asset.name !== assetName ||
+        !Number.isSafeInteger(asset.size) ||
+        asset.size <= 0 ||
+        asset.size > MAX_RELEASE_ASSET_BYTES ||
+        !safeReleaseUrl({
+          url: asset.browser_download_url,
+          fullName,
+          tag,
+          assetName,
+        })
+      ) {
+        continue;
+      }
+      candidates.push({
+        releaseTgzUrl: asset.browser_download_url,
+        releaseTag: tag,
+        releasePrerelease: release.prerelease,
+        releaseAssetName: assetName,
+        releaseAssetSize: asset.size,
+        releaseAssetDigest:
+          typeof asset.digest === "string" && /^sha256:[0-9a-f]{64}$/i.test(asset.digest)
+            ? asset.digest.toLowerCase()
+            : null,
+      });
+    }
+  }
+
+  return candidates.length === 1 ? candidates[0] : null;
+}
 
 /** 入口落在构建产物目录里 → git 装拉到的源码树里不存在这个文件。 */
 const BUILD_DIR = /(?:^|[/"])(?:lib|dist|build|out|esm|cjs)\//;
@@ -45,6 +163,7 @@ export function manifestFacts(pkg) {
   if (!pkg || typeof pkg !== "object") {
     return {
       pkgName: null,
+      pkgVersion: null,
       pkgPrivate: false,
       hasBundle: false,
       hasPrepare: false,
@@ -53,6 +172,7 @@ export function manifestFacts(pkg) {
   }
   return {
     pkgName: typeof pkg.name === "string" ? pkg.name : null,
+    pkgVersion: typeof pkg.version === "string" ? pkg.version : null,
     pkgPrivate: pkg.private === true,
     // 官方约定就是 dsh.bundle 指向一份 cordis.patch.yml；没有这个字段 dsh 不会把它
     // 追加进 dsh.profile.bundles，装进去也只是一条永远不会被装配的依赖
@@ -73,15 +193,60 @@ function profileFor({ fullName, pkgName }) {
 
 /**
  * 推导结论 + 可直接粘贴的命令。
- * facts 为 manifestFacts() 的结果加上 npmPublished（npm registry 上是否真存在）。
+ * facts 为 manifestFacts() 的结果加上 npmPublished 与已筛选的 release 元数据。
  */
 export function deriveInstall({ fullName, npmPublished, ...facts }) {
-  const { pkgName, pkgPrivate, hasBundle, hasPrepare, entryNeedsBuild } = facts;
+  const {
+    pkgName,
+    pkgVersion,
+    pkgPrivate,
+    hasBundle,
+    hasPrepare,
+    entryNeedsBuild,
+    releaseTgzUrl,
+    releaseTag,
+    releasePrerelease,
+    releaseAssetName,
+    releaseAssetSize,
+    releaseAssetDigest,
+  } = facts;
   const profile = profileFor({ fullName, pkgName });
 
   // 不是组合包就没有安装这回事：索引仓库、文档站、独立 App、宿主本体都落这里
   if (!pkgName) return { kind: "not-installable", reason: "no-manifest", cmd: null, profile };
   if (!hasBundle) return { kind: "not-installable", reason: "no-bundle", cmd: null, profile };
+
+  // Release tarball 不走 git prepare / allowBuilds。入库事实也重新校验，
+  // 避免旧数据或人工写库绕过 URL、包名与版本约束。
+  const release = selectReleaseTarball({
+    fullName,
+    pkgName,
+    pkgVersion,
+    releases: [
+      {
+        draft: false,
+        prerelease: releasePrerelease,
+        tag_name: releaseTag,
+        assets: [
+          {
+            state: "uploaded",
+            name: releaseAssetName,
+            size: releaseAssetSize,
+            digest: releaseAssetDigest,
+            browser_download_url: releaseTgzUrl,
+          },
+        ],
+      },
+    ],
+  });
+  if (release) {
+    return {
+      kind: "release",
+      reason: null,
+      cmd: `dsh plugin --profile ${profile} add ${release.releaseTgzUrl}`,
+      profile,
+    };
+  }
 
   // 发布过就用包名——避开 git 装源码那一整套坑
   if (npmPublished && !pkgPrivate) {

--- a/scripts/lib/install.test.mjs
+++ b/scripts/lib/install.test.mjs
@@ -1,0 +1,254 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import {
+  MAX_RELEASE_ASSET_BYTES,
+  deriveInstall,
+  manifestFacts,
+  selectReleaseTarball,
+} from "./install.mjs";
+
+const FULL_NAME = "example/dsh-widget";
+const PKG_NAME = "dsh-widget";
+const VERSION = "1.2.3";
+
+function githubRelease({
+  draft = false,
+  prerelease = false,
+  tag = `v${VERSION}`,
+  assetName = `${PKG_NAME}-${VERSION}.tgz`,
+  url = `https://github.com/${FULL_NAME}/releases/download/${tag}/${assetName}`,
+  size = 1_024,
+  state = "uploaded",
+} = {}) {
+  return {
+    draft,
+    prerelease,
+    tag_name: tag,
+    assets: [
+      {
+        name: assetName,
+        browser_download_url: url,
+        size,
+        state,
+        digest: `sha256:${"a".repeat(64)}`,
+      },
+    ],
+  };
+}
+
+function releaseFacts(overrides = {}) {
+  const selected = selectReleaseTarball({
+    fullName: FULL_NAME,
+    pkgName: PKG_NAME,
+    pkgVersion: VERSION,
+    releases: [githubRelease(overrides)],
+  });
+  assert.ok(selected);
+  return selected;
+}
+
+function installFacts(overrides = {}) {
+  return {
+    fullName: FULL_NAME,
+    pkgName: PKG_NAME,
+    pkgVersion: VERSION,
+    pkgPrivate: false,
+    hasBundle: true,
+    hasPrepare: false,
+    entryNeedsBuild: true,
+    npmPublished: false,
+    releaseTgzUrl: null,
+    releaseTag: null,
+    releasePrerelease: false,
+    releaseAssetName: null,
+    releaseAssetSize: null,
+    releaseAssetDigest: null,
+    ...overrides,
+  };
+}
+
+test("manifestFacts preserves the package version used to bind releases", () => {
+  assert.deepEqual(
+    manifestFacts({
+      name: PKG_NAME,
+      version: VERSION,
+      dsh: { bundle: "cordis.patch.yml" },
+      main: "dist/index.js",
+    }),
+    {
+      pkgName: PKG_NAME,
+      pkgVersion: VERSION,
+      pkgPrivate: false,
+      hasBundle: true,
+      hasPrepare: false,
+      entryNeedsBuild: true,
+    },
+  );
+});
+
+test("selects one uploaded GitHub asset whose tag, package, and version match", () => {
+  const selected = selectReleaseTarball({
+    fullName: FULL_NAME,
+    pkgName: PKG_NAME,
+    pkgVersion: VERSION,
+    releases: [githubRelease()],
+  });
+  assert.deepEqual(selected, {
+    releaseTgzUrl:
+      "https://github.com/example/dsh-widget/releases/download/v1.2.3/dsh-widget-1.2.3.tgz",
+    releaseTag: "v1.2.3",
+    releasePrerelease: false,
+    releaseAssetName: "dsh-widget-1.2.3.tgz",
+    releaseAssetSize: 1_024,
+    releaseAssetDigest: `sha256:${"a".repeat(64)}`,
+  });
+});
+
+test("uses npm-pack naming for scoped packages", () => {
+  const pkgName = "@scope/dsh-widget";
+  const assetName = "scope-dsh-widget-1.2.3.tgz";
+  assert.ok(
+    selectReleaseTarball({
+      fullName: FULL_NAME,
+      pkgName,
+      pkgVersion: VERSION,
+      releases: [githubRelease({ assetName })],
+    }),
+  );
+});
+
+test("ignores draft releases", () => {
+  assert.equal(
+    selectReleaseTarball({
+      fullName: FULL_NAME,
+      pkgName: PKG_NAME,
+      pkgVersion: VERSION,
+      releases: [githubRelease({ draft: true })],
+    }),
+    null,
+  );
+});
+
+test("requires prerelease metadata to agree with a prerelease package version", () => {
+  const pkgVersion = "1.2.3-rc.1";
+  const assetName = `${PKG_NAME}-${pkgVersion}.tgz`;
+  const accepted = githubRelease({
+    prerelease: true,
+    tag: `v${pkgVersion}`,
+    assetName,
+    url: `https://github.com/${FULL_NAME}/releases/download/v${pkgVersion}/${assetName}`,
+  });
+  assert.ok(
+    selectReleaseTarball({
+      fullName: FULL_NAME,
+      pkgName: PKG_NAME,
+      pkgVersion,
+      releases: [accepted],
+    }),
+  );
+  assert.equal(
+    selectReleaseTarball({
+      fullName: FULL_NAME,
+      pkgName: PKG_NAME,
+      pkgVersion,
+      releases: [{ ...accepted, prerelease: false }],
+    }),
+    null,
+  );
+  assert.equal(
+    selectReleaseTarball({
+      fullName: FULL_NAME,
+      pkgName: PKG_NAME,
+      pkgVersion: VERSION,
+      releases: [githubRelease({ prerelease: true })],
+    }),
+    null,
+  );
+});
+
+test("rejects wrong filenames and host-spoofed or decorated URLs", () => {
+  for (const release of [
+    githubRelease({ assetName: "other-1.2.3.tgz" }),
+    githubRelease({
+      url: "https://github.com.evil.example/example/dsh-widget/releases/download/v1.2.3/dsh-widget-1.2.3.tgz",
+    }),
+    githubRelease({
+      url: "https://github.com/example/dsh-widget/releases/download/v1.2.3/dsh-widget-1.2.3.tgz?token=surprise",
+    }),
+  ]) {
+    assert.equal(
+      selectReleaseTarball({
+        fullName: FULL_NAME,
+        pkgName: PKG_NAME,
+        pkgVersion: VERSION,
+        releases: [release],
+      }),
+      null,
+    );
+  }
+});
+
+test("rejects oversized, incomplete, and ambiguous assets", () => {
+  for (const release of [
+    githubRelease({ size: MAX_RELEASE_ASSET_BYTES + 1 }),
+    githubRelease({ state: "new" }),
+  ]) {
+    assert.equal(
+      selectReleaseTarball({
+        fullName: FULL_NAME,
+        pkgName: PKG_NAME,
+        pkgVersion: VERSION,
+        releases: [release],
+      }),
+      null,
+    );
+  }
+  assert.equal(
+    selectReleaseTarball({
+      fullName: FULL_NAME,
+      pkgName: PKG_NAME,
+      pkgVersion: VERSION,
+      releases: [githubRelease(), githubRelease()],
+    }),
+    null,
+  );
+});
+
+test("prefers a safe release tarball over npm and build-required fallbacks", () => {
+  const selected = releaseFacts();
+  assert.deepEqual(
+    deriveInstall(installFacts({ ...selected, npmPublished: true })),
+    {
+      kind: "release",
+      reason: null,
+      cmd: "dsh plugin --profile web add https://github.com/example/dsh-widget/releases/download/v1.2.3/dsh-widget-1.2.3.tgz",
+      profile: "web",
+    },
+  );
+});
+
+test("revalidates stored release metadata before generating a command", () => {
+  const selected = releaseFacts();
+  assert.equal(
+    deriveInstall(
+      installFacts({
+        ...selected,
+        releaseTgzUrl:
+          "https://evil.example/example/dsh-widget/releases/download/v1.2.3/dsh-widget-1.2.3.tgz",
+        npmPublished: true,
+      }),
+    ).kind,
+    "npm",
+  );
+});
+
+test("preserves npm, build-required, git, and not-installable fallbacks", () => {
+  assert.equal(deriveInstall(installFacts({ npmPublished: true })).kind, "npm");
+  assert.equal(deriveInstall(installFacts()).kind, "build-required");
+  assert.equal(
+    deriveInstall(installFacts({ entryNeedsBuild: false })).kind,
+    "git",
+  );
+  assert.equal(deriveInstall(installFacts({ hasBundle: false })).kind, "not-installable");
+});

--- a/scripts/probe-install.mjs
+++ b/scripts/probe-install.mjs
@@ -10,16 +10,22 @@
  *   pnpm probe:install --rederive          # 不联网，用库里已有事实按当前规则重算 kind/cmd
  *   pnpm probe:install --dry-run           # 只打印，不写库
  *
- * 探两个来源：仓库根 package.json（raw.githubusercontent，免鉴权）与 npm registry。
+ * 探三个来源：仓库根 package.json、npm registry，以及有限的 GitHub Releases 元数据。
  * 推导规则在 scripts/lib/install.mjs——改规则后跑 --rederive 即可全库生效，无需重新联网抓。
  *
  * 运营手工设的 plugins.install_cmd 优先级最高，本脚本从不覆盖它。
  */
+import { execFileSync } from "node:child_process";
 import { createClient } from "@libsql/client/web";
 
 import { deriveInstall, manifestFacts } from "./lib/install.mjs";
+import {
+  fetchRelease,
+  mergeReleaseProbe,
+  probeTimestamp,
+} from "./lib/github-release-probe.mjs";
 
-const CONCURRENCY = 12;
+const CONCURRENCY = 8;
 const DEFAULT_STALE_DAYS = 7;
 
 // ---------- 参数 ----------
@@ -35,6 +41,23 @@ const staleDays = Number(opt("--stale-days", DEFAULT_STALE_DAYS));
 const dryRun = has("--dry-run");
 const rederive = has("--rederive");
 const all = has("--all");
+
+function githubToken() {
+  if (process.env.GITHUB_TOKEN) return process.env.GITHUB_TOKEN.trim();
+  try {
+    return execFileSync("gh", ["auth", "token"], {
+      encoding: "utf8",
+      stdio: ["ignore", "pipe", "ignore"],
+    }).trim();
+  } catch {
+    return null;
+  }
+}
+
+const token = rederive ? null : githubToken();
+if (!rederive && !token) {
+  console.warn("⚠️ 未找到 GITHUB_TOKEN / gh 登录，将使用每小时 60 次的匿名 API 限额");
+}
 
 function db() {
   const url = process.env.TURSO_DATABASE_URL;
@@ -87,11 +110,14 @@ async function fetchNpmPublished(name, isPrivate) {
   }
 }
 
-async function probe(fullName) {
+async function probe(fullName, previousRelease) {
   const pkg = await fetchManifest(fullName);
-  const facts = manifestFacts(pkg);
-  const npmPublished = await fetchNpmPublished(facts.pkgName, facts.pkgPrivate);
-  return { ...facts, npmPublished };
+  const manifest = manifestFacts(pkg);
+  const [npmPublished, release] = await Promise.all([
+    fetchNpmPublished(manifest.pkgName, manifest.pkgPrivate),
+    fetchRelease({ fullName, manifest, token }),
+  ]);
+  return mergeReleaseProbe({ manifest, npmPublished, release, previousRelease });
 }
 
 // ---------- 主流程 ----------
@@ -101,11 +127,18 @@ const client = db();
 // 列可能已存在，duplicate column 忽略即可（与 sync-plugins-db.mjs 的迁移写法一致）
 for (const sql of [
   `ALTER TABLE plugins ADD COLUMN pkg_name TEXT`,
+  `ALTER TABLE plugins ADD COLUMN pkg_version TEXT`,
   `ALTER TABLE plugins ADD COLUMN pkg_private INTEGER`,
   `ALTER TABLE plugins ADD COLUMN has_bundle INTEGER`,
   `ALTER TABLE plugins ADD COLUMN has_prepare INTEGER`,
   `ALTER TABLE plugins ADD COLUMN entry_needs_build INTEGER`,
   `ALTER TABLE plugins ADD COLUMN npm_published INTEGER`,
+  `ALTER TABLE plugins ADD COLUMN release_tgz_url TEXT`,
+  `ALTER TABLE plugins ADD COLUMN release_tag TEXT`,
+  `ALTER TABLE plugins ADD COLUMN release_prerelease INTEGER`,
+  `ALTER TABLE plugins ADD COLUMN release_asset_name TEXT`,
+  `ALTER TABLE plugins ADD COLUMN release_asset_size INTEGER`,
+  `ALTER TABLE plugins ADD COLUMN release_asset_digest TEXT`,
   `ALTER TABLE plugins ADD COLUMN install_kind TEXT`,
   `ALTER TABLE plugins ADD COLUMN install_cmd_auto TEXT`,
   `ALTER TABLE plugins ADD COLUMN install_probed_at TEXT`,
@@ -117,8 +150,10 @@ for (const sql of [
   }
 }
 
-let sql = `SELECT full_name, pkg_name, pkg_private, has_bundle, has_prepare,
-                  entry_needs_build, npm_published, install_probed_at
+let sql = `SELECT full_name, pkg_name, pkg_version, pkg_private, has_bundle, has_prepare,
+                  entry_needs_build, npm_published, release_tgz_url, release_tag,
+                  release_prerelease, release_asset_name, release_asset_size,
+                  release_asset_digest, install_probed_at
            FROM plugins WHERE is_present = 1 AND is_offtopic = 0`;
 const args = [];
 if (only.length) {
@@ -137,30 +172,51 @@ const rows = (await client.execute({ sql, args })).rows;
 console.log(
   rederive
     ? `重算 ${rows.length} 个仓库的安装结论（不联网）…`
-    : `探测 ${rows.length} 个仓库的 package.json / npm…`,
+    : `探测 ${rows.length} 个仓库的 package.json / npm / GitHub Releases…`,
 );
 if (!rows.length) process.exit(0);
 
+const now = new Date().toISOString();
 let done = 0;
 const results = await mapPool(rows, CONCURRENCY, async (r) => {
   const fullName = String(r.full_name);
-  const facts = rederive
+  const previousRelease = {
+    releaseTgzUrl: r.release_tgz_url == null ? null : String(r.release_tgz_url),
+    releaseTag: r.release_tag == null ? null : String(r.release_tag),
+    releasePrerelease: Boolean(r.release_prerelease),
+    releaseAssetName: r.release_asset_name == null ? null : String(r.release_asset_name),
+    releaseAssetSize: r.release_asset_size == null ? null : Number(r.release_asset_size),
+    releaseAssetDigest:
+      r.release_asset_digest == null ? null : String(r.release_asset_digest),
+  };
+  const result = rederive
     ? {
-        pkgName: r.pkg_name == null ? null : String(r.pkg_name),
-        pkgPrivate: Boolean(r.pkg_private),
-        hasBundle: Boolean(r.has_bundle),
-        hasPrepare: Boolean(r.has_prepare),
-        entryNeedsBuild: Boolean(r.entry_needs_build),
-        npmPublished: Boolean(r.npm_published),
+        facts: {
+          pkgName: r.pkg_name == null ? null : String(r.pkg_name),
+          pkgVersion: r.pkg_version == null ? null : String(r.pkg_version),
+          pkgPrivate: Boolean(r.pkg_private),
+          hasBundle: Boolean(r.has_bundle),
+          hasPrepare: Boolean(r.has_prepare),
+          entryNeedsBuild: Boolean(r.entry_needs_build),
+          npmPublished: Boolean(r.npm_published),
+          ...previousRelease,
+        },
+        complete: true,
       }
-    : await probe(fullName);
+    : await probe(fullName, previousRelease);
   if (!rederive && ++done % 100 === 0) console.log(`  …${done}/${rows.length}`);
   return {
     fullName,
-    facts,
-    derived: deriveInstall({ fullName, ...facts }),
-    // 重算模式只改结论，不谎报探测时间
-    probedAt: r.install_probed_at == null ? null : String(r.install_probed_at),
+    facts: result.facts,
+    derived: deriveInstall({ fullName, ...result.facts }),
+    // 重算模式不改时间；release API 失败则保留旧时间，让下一轮立即重试。
+    probedAt: probeTimestamp({
+      rederive,
+      complete: result.complete,
+      previous:
+        r.install_probed_at == null ? null : String(r.install_probed_at),
+      now,
+    }),
   };
 });
 
@@ -182,23 +238,31 @@ if (dryRun) {
   process.exit(0);
 }
 
-const now = new Date().toISOString();
 const stmts = results.map(({ fullName, facts, derived, probedAt }) => ({
   sql: `UPDATE plugins SET
-          pkg_name = ?, pkg_private = ?, has_bundle = ?, has_prepare = ?,
-          entry_needs_build = ?, npm_published = ?,
+          pkg_name = ?, pkg_version = ?, pkg_private = ?, has_bundle = ?, has_prepare = ?,
+          entry_needs_build = ?, npm_published = ?, release_tgz_url = ?, release_tag = ?,
+          release_prerelease = ?, release_asset_name = ?, release_asset_size = ?,
+          release_asset_digest = ?,
           install_kind = ?, install_cmd_auto = ?, install_probed_at = ?
         WHERE full_name = ?`,
   args: [
     facts.pkgName,
+    facts.pkgVersion,
     facts.pkgPrivate ? 1 : 0,
     facts.hasBundle ? 1 : 0,
     facts.hasPrepare ? 1 : 0,
     facts.entryNeedsBuild ? 1 : 0,
     facts.npmPublished ? 1 : 0,
+    facts.releaseTgzUrl,
+    facts.releaseTag,
+    facts.releasePrerelease ? 1 : 0,
+    facts.releaseAssetName,
+    facts.releaseAssetSize,
+    facts.releaseAssetDigest,
     derived.kind,
     derived.cmd,
-    rederive ? probedAt : now,
+    probedAt,
     fullName,
   ],
 }));

--- a/scripts/sync-plugins-db.mjs
+++ b/scripts/sync-plugins-db.mjs
@@ -250,14 +250,21 @@ const MIGRATIONS = [
   `ALTER TABLE plugins ADD COLUMN is_official INTEGER NOT NULL DEFAULT 0`,
   `ALTER TABLE plugins ADD COLUMN install_cmd TEXT`, // 详情页安装命令覆盖（与语言无关，运营维护）
   // 安装方式探测（scripts/probe-install.mjs 填，规则见 scripts/lib/install.mjs）：
-  // 前六列是 package.json / npm registry 上的客观事实，后三列是据此推出的结论。
+  // package.json / npm / GitHub Releases 的客观事实，最后三列是据此推出的结论。
   `ALTER TABLE plugins ADD COLUMN pkg_name TEXT`,
+  `ALTER TABLE plugins ADD COLUMN pkg_version TEXT`,
   `ALTER TABLE plugins ADD COLUMN pkg_private INTEGER`,
   `ALTER TABLE plugins ADD COLUMN has_bundle INTEGER`, // package.json 声明了 dsh.bundle
   `ALTER TABLE plugins ADD COLUMN has_prepare INTEGER`,
   `ALTER TABLE plugins ADD COLUMN entry_needs_build INTEGER`, // 入口指向 lib/ dist/ 等构建产物
   `ALTER TABLE plugins ADD COLUMN npm_published INTEGER`,
-  `ALTER TABLE plugins ADD COLUMN install_kind TEXT`, // npm / git / build-required / not-installable
+  `ALTER TABLE plugins ADD COLUMN release_tgz_url TEXT`,
+  `ALTER TABLE plugins ADD COLUMN release_tag TEXT`,
+  `ALTER TABLE plugins ADD COLUMN release_prerelease INTEGER`,
+  `ALTER TABLE plugins ADD COLUMN release_asset_name TEXT`,
+  `ALTER TABLE plugins ADD COLUMN release_asset_size INTEGER`,
+  `ALTER TABLE plugins ADD COLUMN release_asset_digest TEXT`,
+  `ALTER TABLE plugins ADD COLUMN install_kind TEXT`, // release / npm / git / build-required / not-installable
   `ALTER TABLE plugins ADD COLUMN install_cmd_auto TEXT`, // 推导出的命令；install_cmd 为空时用它
   `ALTER TABLE plugins ADD COLUMN install_probed_at TEXT`,
 ];

--- a/src/app/[locale]/plugins/[owner]/[repo]/page.tsx
+++ b/src/app/[locale]/plugins/[owner]/[repo]/page.tsx
@@ -232,6 +232,7 @@ export default async function PluginDetailPage({
                   : t("detailInstall")}
             </CardTitle>
             {(installKind === "curated" ||
+              installKind === "release" ||
               installKind === "npm" ||
               installKind === "git") && (
               <Badge
@@ -276,7 +277,13 @@ export default async function PluginDetailPage({
               {t("installGitNote")}
             </p>
           )}
-          {(installKind === "npm" ||
+          {installKind === "release" && (
+            <p className="text-xs leading-relaxed text-muted-foreground">
+              {t("installReleaseNote")}
+            </p>
+          )}
+          {(installKind === "release" ||
+            installKind === "npm" ||
             installKind === "git" ||
             installKind === "build-required") && (
             <p className="text-xs leading-relaxed text-muted-foreground">

--- a/src/lib/plugins-db.ts
+++ b/src/lib/plugins-db.ts
@@ -70,10 +70,15 @@ function staticFallback(): PluginsPageData {
 
 /**
  * 安装方式结论（scripts/lib/install.mjs 推导，probe-install.mjs 入库）：
- * npm 已发布用包名装 / git 未发布但源码能跑 / build-required 需自行构建 /
- * not-installable 压根不是插件包。
+ * release 有唯一的版本匹配 tarball / npm 已发布用包名装 / git 未发布但源码能跑 /
+ * build-required 需自行构建 / not-installable 压根不是插件包。
  */
-export type InstallKind = "npm" | "git" | "build-required" | "not-installable";
+export type InstallKind =
+  | "release"
+  | "npm"
+  | "git"
+  | "build-required"
+  | "not-installable";
 
 /** 详情页数据：PluginWithGrowth + 评分明细与运维时间戳。 */
 export interface PluginDetail extends PluginWithGrowth {


### PR DESCRIPTION
Closes #3

## What changed

- Probe GitHub Releases for one uniquely matching plugin tarball and add a `release` install kind.
- Persist package version plus bounded release metadata, then revalidate the stored facts before rendering an install command.
- Preserve the existing install order: curated/manual override first, then release tarball, npm, and the existing git/build-required fallbacks.
- Keep failed release probes retryable: HTTP errors, network errors, and oversized metadata preserve prior release facts and do not advance `install_probed_at`.
- Surface the release path and its trust boundary in all four locales.

## Selection and safety rules

A release tarball is selected only when all of these agree:

- the root package is a DSH bundle with a valid npm package name and version;
- the GitHub release is non-draft, and its prerelease flag agrees with the package version;
- the release tag is exactly `<version>` or `v<version>`;
- exactly one uploaded asset has the canonical `npm pack` filename for that package/version;
- the asset is non-empty, at most 100 MiB, and has an undecorated HTTPS download URL on `github.com` for that exact repository/tag/filename.

The probe makes at most one Releases API request for each eligible manifest, examines at most 10 releases and 50 assets per release, and reads at most 1.5 MiB of response metadata. It does **not** download, unpack, inspect, or execute release assets. Ambiguous or invalid metadata falls back to npm/git/build-required behavior.

## Why

Some DeepSeek Harness plugins publish a versioned GitHub Release tarball but no npm package. `dsh plugin add` accepts tarball URLs directly, avoiding the git-source `prepare` / pnpm `allowBuilds` friction while retaining the existing fallbacks for repositories without a safe match.

## Disclosure

I maintain `labmimors/dsh-mcp-lens`; [hikariming/dshfind#3](https://github.com/hikariming/dshfind/issues/3) was motivated by that plugin's install friction. This contribution implements a repository-agnostic rule and contains no special case for dsh-mcp-lens.

## Validation

- `pnpm test` — pass, 14/14 Node tests.
- Changed-file ESLint — pass.
- `pnpm exec next typegen` — pass.
- `pnpm exec tsc --noEmit` — pass.
- `pnpm build` — pass. The build used the project's static-data fallback because Turso credentials were intentionally absent.
- Live GitHub metadata probe — selected the exact `dsh-mcp-lens-0.1.0-rc.6.tgz` asset without fetching its body.
- `pnpm lint` — still fails on five existing errors outside this diff (`lesson-progress.tsx`, `locale-switcher.tsx`, `theme-toggle.tsx`, `typewriter.tsx`, and `registry.ts`); linting every changed source file passes.
- Hosted Vercel status is currently failed because the check redirects to a third-party authorization page; it did not run a deployment and is not counted as a passing validation.

## Residual limitations

- Matching is metadata validation, not tarball-content attestation. A publisher can replace release contents; the installer should still apply its normal trust policy.
- GitHub-provided SHA-256 metadata is stored when available, but the generated DSH command cannot pin that digest today.
- Only the newest 10 releases / first 50 assets are considered; older matches deliberately fall back.
- The repository has no component render-test harness, so the small UI branch is covered by TypeScript/build rather than a dedicated render test.
