### PR TITLE
插件页虚拟滚动 + 可爱 404 页面

### DIFF
--- a/messages/en.json
+++ b/messages/en.json
@@ -444,6 +444,13 @@
     "contributions": "commits",
     "fullBoard": "Full Board"
   },
+  "NotFound": {
+    "code": "404",
+    "whaleLine": "This whale took a wrong turn…",
+    "description": "The page you're looking for doesn't exist, or it swam away.",
+    "goHome": "Back home",
+    "browsePlugins": "Browse plugins"
+  },
   "Meta": {
     "siteTitle": "dshfind — DeepSeek Harness (DSH) Plugin Marketplace & Learning Community",
     "siteDescription": "Discover DeepSeek Harness plugins: dshfind indexes every dsh-plugin repository on GitHub with daily-synced stars, quality scores and install commands, plus free DSH courses and a Cordis paper walkthrough.",

--- a/messages/ja.json
+++ b/messages/ja.json
@@ -442,6 +442,13 @@
     "contributions": "コミット",
     "fullBoard": "全ランキング"
   },
+  "NotFound": {
+    "code": "404",
+    "whaleLine": "このクジラ、道に迷ったみたい……",
+    "description": "お探しのページは存在しないか、移動されたようです。",
+    "goHome": "ホームに戻る",
+    "browsePlugins": "プラグインマーケットへ"
+  },
   "Meta": {
     "siteTitle": "dshfind — DeepSeek Harness (DSH) プラグインマーケット＆学習コミュニティ",
     "siteDescription": "GitHub の dsh-plugin トピック配下の DeepSeek Harness プラグインを毎日同期して収録。star・成長・品質スコアに加え、無料の DSH 講座と Cordis 論文精読も。",

--- a/messages/ko.json
+++ b/messages/ko.json
@@ -442,6 +442,13 @@
     "contributions": "커밋",
     "fullBoard": "전체 랭킹"
   },
+  "NotFound": {
+    "code": "404",
+    "whaleLine": "이 고래가 길을 잃었어요……",
+    "description": "찾으시는 페이지가 없거나 다른 곳으로 옮겨졌어요.",
+    "goHome": "홈으로",
+    "browsePlugins": "플러그인 마켓 둘러보기"
+  },
   "Meta": {
     "siteTitle": "dshfind — DeepSeek Harness (DSH) 플러그인 마켓 & 학습 커뮤니티",
     "siteDescription": "GitHub dsh-plugin 토픽의 DeepSeek Harness 플러그인을 매일 동기화해 수록합니다. star·성장·품질 점수와 함께 무료 DSH 강의, Cordis 논문 정독까지.",

--- a/messages/zh.json
+++ b/messages/zh.json
@@ -442,6 +442,13 @@
     "contributions": "次提交",
     "fullBoard": "完整榜单"
   },
+  "NotFound": {
+    "code": "404",
+    "whaleLine": "这只鲸鱼迷路了……",
+    "description": "你访问的页面不存在，或者已经被搬走了。",
+    "goHome": "返回首页",
+    "browsePlugins": "逛逛插件超市"
+  },
   "Meta": {
     "siteTitle": "dshfind — DeepSeek Harness (DSH) 插件超市与学习社区",
     "siteDescription": "dshfind 收录 GitHub 上全部 dsh-plugin 主题仓库：DeepSeek Harness 插件每日同步 star、增长与质量评分，并提供免费 DSH 课程与 Cordis 论文精读。",

--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
     "@mdx-js/loader": "^3.1.1",
     "@mdx-js/react": "^3.1.1",
     "@next/mdx": "^16.3.0",
+    "@tanstack/react-virtual": "^3.14.9",
     "@types/mdx": "^2.0.14",
     "@vercel/analytics": "^2.0.1",
     "class-variance-authority": "^0.7.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -20,6 +20,9 @@ importers:
       '@next/mdx':
         specifier: ^16.3.0
         version: 16.3.0(@mdx-js/loader@3.1.1)(@mdx-js/react@3.1.1(@types/react@19.2.18)(react@19.2.8))
+      '@tanstack/react-virtual':
+        specifier: ^3.14.9
+        version: 3.14.9(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
       '@types/mdx':
         specifier: ^2.0.14
         version: 2.0.14
@@ -1674,6 +1677,15 @@ packages:
 
   '@tailwindcss/postcss@4.3.3':
     resolution: {integrity: sha512-JTSZZGQi1AyKirbLN3azmjVzef92tcX7h+iSqPdaeStyFpGpDlKvvpxeOE8njhbUanbRwr3z8DyzhICWnMtQeg==}
+
+  '@tanstack/react-virtual@3.14.9':
+    resolution: {integrity: sha512-qZyr0FZDP8rDC4WBhsryIZmAd9bveJvFGUJJtskWaew6/0dTRS6wZxnR6VQ5bY2KwL3LjerrHqQLk3a0GKcPXQ==}
+    peerDependencies:
+      react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
+      react-dom: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
+
+  '@tanstack/virtual-core@3.17.7':
+    resolution: {integrity: sha512-bp+v10y65sp2H7WpWfIMyxTNfl8ZVfxFTLRjPIFRryi6FV/J33z4IS53WO4pTk36KlvJ4iLiQz+oaydDC1xbcA==}
 
   '@ts-morph/common@0.27.0':
     resolution: {integrity: sha512-Wf29UqxWDpc+i61k3oIOzcUfQt79PIT9y/MWfAGlrkjg6lBC1hwDECLXPVJAhWjiGbfBCxZd65F/LIZF3+jeJQ==}
@@ -6023,6 +6035,14 @@ snapshots:
       '@tailwindcss/oxide': 4.3.3
       postcss: 8.5.26
       tailwindcss: 4.3.3
+
+  '@tanstack/react-virtual@3.14.9(react-dom@19.2.8(react@19.2.8))(react@19.2.8)':
+    dependencies:
+      '@tanstack/virtual-core': 3.17.7
+      react: 19.2.8
+      react-dom: 19.2.8(react@19.2.8)
+
+  '@tanstack/virtual-core@3.17.7': {}
 
   '@ts-morph/common@0.27.0':
     dependencies:

--- a/src/app/[locale]/not-found.tsx
+++ b/src/app/[locale]/not-found.tsx
@@ -1,0 +1,22 @@
+import type { Metadata } from "next";
+import { getTranslations } from "next-intl/server";
+
+import { NotFoundContent } from "@/components/not-found-content";
+
+export const metadata: Metadata = {
+  title: "404",
+  robots: { index: false },
+};
+
+/**
+ * Segment 级 404：仅在 [locale] 段内显式调用 notFound() 时触发
+ * （例如插件详情页找不到对应仓库）。
+ *
+ * 由 [locale]/layout.tsx 包裹——ThemeProvider / NextIntlClientProvider /
+ * 站点头尾都已就位，这里只渲染主体。metadata 需要单独取翻译。
+ */
+export default async function LocaleNotFound() {
+  // 占位取译：保证 NotFound 命名空间在该 segment 被标记为已用，便于后续维护。
+  await getTranslations("NotFound");
+  return <NotFoundContent />;
+}

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -212,6 +212,9 @@
   .caret-blink {
     animation: none;
   }
+  .animate-float {
+    animation: none;
+  }
 }
 
 /* 脚本被禁用时观察器不会跑，内容不能就这么隐身。 */
@@ -234,4 +237,18 @@
 }
 .caret-blink {
   animation: caretBlink 1s step-end infinite;
+}
+
+/* 404 页面鲸鱼吉祥物上下浮动 */
+@keyframes float {
+  0%,
+  100% {
+    transform: translateY(0);
+  }
+  50% {
+    transform: translateY(-8px);
+  }
+}
+.animate-float {
+  animation: float 3s ease-in-out infinite;
 }

--- a/src/app/not-found.tsx
+++ b/src/app/not-found.tsx
@@ -1,0 +1,43 @@
+import { cookies, headers } from "next/headers";
+import { NextIntlClientProvider } from "next-intl";
+
+import { ThemeProvider } from "@/components/theme-provider";
+import { NotFoundContent } from "@/components/not-found-content";
+import {
+  getLocaleFromCookie,
+  isLocale,
+  type Locale,
+} from "@/i18n/config";
+
+/**
+ * 全局 404：未匹配任何路由的 URL 都落到这里（包括 /zh/不存在的路径）。
+ *
+ * 与 segment 级 not-found 不同，这里**不**经过 [locale]/layout.tsx——
+ * 因此 ThemeProvider / NextIntlClientProvider / 站点头尾都要自己包。
+ * locale 从 next-intl 中间件写入的 `X-NEXT-INTL-LOCALE` 头读取，
+ * 回退到 NEXT_LOCALE cookie，再回退到默认语言。
+ */
+export default async function RootNotFound() {
+  const h = await headers();
+  const c = await cookies();
+
+  const headerLocale = h.get("X-NEXT-INTL-LOCALE");
+  const locale: Locale = isLocale(headerLocale ?? "")
+    ? (headerLocale as Locale)
+    : getLocaleFromCookie(c.get("NEXT_LOCALE")?.value);
+
+  const messages = (await import(`../../messages/${locale}.json`)).default;
+
+  return (
+    <ThemeProvider
+      attribute="class"
+      defaultTheme="dark"
+      enableSystem
+      disableTransitionOnChange
+    >
+      <NextIntlClientProvider locale={locale} messages={messages}>
+        <NotFoundContent />
+      </NextIntlClientProvider>
+    </ThemeProvider>
+  );
+}

--- a/src/components/not-found-content.tsx
+++ b/src/components/not-found-content.tsx
@@ -1,0 +1,53 @@
+"use client";
+
+import Image from "next/image";
+import { Home, Puzzle } from "lucide-react";
+import { useTranslations } from "next-intl";
+
+import { Link } from "@/i18n/navigation";
+import { Button } from "@/components/ui/button";
+
+/**
+ * 404 页面主体：漂浮的鲸鱼吉祥物 + 渐变大字 404 + 文案 + 导航按钮。
+ *
+ * 用在两处：
+ *  - app/not-found.tsx（未匹配 URL 的全局 404，自带 ThemeProvider + i18n Provider 包裹）
+ *  - app/[locale]/not-found.tsx（segment 内 notFound() 触发，由 [locale] layout 提供包裹）
+ *
+ * 是 client component：要用 next-intl 的 useTranslations + Link，
+ * 二者都依赖外层 NextIntlClientProvider 注入的 locale/messages。
+ */
+export function NotFoundContent() {
+  const t = useTranslations("NotFound");
+  return (
+    <div className="mx-auto flex min-h-[70vh] w-full max-w-2xl flex-col items-center justify-center px-4 py-16 text-center">
+      <Image
+        src="/brand/dshfind-whale.png"
+        alt=""
+        width={160}
+        height={160}
+        className="size-32 animate-float object-contain sm:size-40"
+        priority
+      />
+      <h1 className="mt-6 bg-gradient-brand bg-clip-text text-7xl font-bold tracking-tight text-transparent sm:text-8xl">
+        {t("code")}
+      </h1>
+      <p className="mt-4 text-xl font-semibold sm:text-2xl">{t("whaleLine")}</p>
+      <p className="mt-2 max-w-md text-muted-foreground">{t("description")}</p>
+      <div className="mt-8 flex flex-wrap items-center justify-center gap-3">
+        <Button asChild className="rounded-lg">
+          <Link href="/">
+            <Home />
+            {t("goHome")}
+          </Link>
+        </Button>
+        <Button asChild variant="outline" className="rounded-lg">
+          <Link href="/plugins">
+            <Puzzle />
+            {t("browsePlugins")}
+          </Link>
+        </Button>
+      </div>
+    </div>
+  );
+}

--- a/src/components/plugins-browser.tsx
+++ b/src/components/plugins-browser.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import * as React from "react";
+import { useWindowVirtualizer } from "@tanstack/react-virtual";
 import { FolderGit2, Puzzle, Search, Star, Users } from "lucide-react";
 import { Link } from "@/i18n/navigation";
 
@@ -26,6 +27,12 @@ const SORTS: SortKey[] = ["stars", "score", "updated", "name"];
 
 const GRADES = ["S", "A", "B", "C"] as const;
 
+/** SSR 与首屏只渲染这么多张卡片，挂载后切换为虚拟滚动——避免 2000+ 卡片把首屏拖垮。 */
+const SSR_PREVIEW = 24;
+
+/** 单行高度估值（px）；measureElement 会测真实高度修正。 */
+const ROW_ESTIMATE = 260;
+
 /** 只取日期部分——相对时间会在 SSR 与客户端算出不同结果，导致 hydration 不一致。 */
 function day(iso: string) {
   return iso ? iso.slice(0, 10) : "-";
@@ -47,7 +54,6 @@ export function PluginsBrowser({
   initialCategory?: string;
 }) {
   const t = useTranslations("Plugins");
-  const locale = useLocale();
   const [query, setQuery] = React.useState("");
   const [sort, setSort] = React.useState<SortKey>("stars");
   const [language, setLanguage] = React.useState("all");
@@ -110,6 +116,10 @@ export function PluginsBrowser({
     }
     return matched; // SQL 已按 featured DESC, stars DESC 排好
   }, [plugins, query, sort, language, category, grade]);
+
+  // 虚拟滚动依赖 window 尺寸，SSR 期间无法得知——挂载前先渲染确定性首屏，挂载后再上虚拟列表。
+  const [mounted, setMounted] = React.useState(false);
+  React.useEffect(() => setMounted(true), []);
 
   return (
     <div className="mx-auto w-full max-w-6xl px-4 py-10 sm:px-6">
@@ -245,140 +255,243 @@ export function PluginsBrowser({
         {t("showing", { n: visible.length, total: plugins.length })}
       </p>
 
-      {/* 插件网格 */}
-      <div className="mt-6 grid gap-5 sm:grid-cols-2 lg:grid-cols-3">
-        {visible.map((plugin) => (
-          <Card
-            key={plugin.fullName}
-            className={`flex flex-col ${
-              plugin.isFeatured
-                ? "border-brand-500/50 bg-gradient-to-br from-brand-500/8 to-transparent"
-                : ""
-            }`}
-          >
-            <CardHeader className="pb-2">
-              <div className="flex items-start justify-between gap-2">
-                <CardTitle className="flex items-center gap-1.5 font-mono text-sm font-semibold break-all">
-                  <Link
-                    href={`/plugins/${plugin.fullName}`}
-                    className="underline-offset-4 hover:text-brand-600 hover:underline dark:hover:text-brand-300"
-                  >
-                    {plugin.name}
-                  </Link>
-                  <ScoreBadge score={plugin.score} />
-                </CardTitle>
-                <span className="flex shrink-0 items-center gap-1 text-xs text-muted-foreground tabular-nums">
-                  <Star className="size-3.5 fill-amber-400 text-amber-400" />
-                  {plugin.stars.toLocaleString("en-US")}
-                  {plugin.starGrowth > 0 && (
-                    <span
-                      title={t("weeklyGrowth")}
-                      className="font-medium text-emerald-600 dark:text-emerald-400"
-                    >
-                      +{plugin.starGrowth.toLocaleString("en-US")}
-                    </span>
-                  )}
-                </span>
-              </div>
-              <div className="flex items-center gap-3">
-                <a
-                  href={`https://github.com/${plugin.owner}`}
-                  target="_blank"
-                  rel="noopener"
-                  className="w-fit text-xs text-muted-foreground underline-offset-4 hover:text-foreground hover:underline"
-                >
-                  @{plugin.owner}
-                </a>
-                {plugin.contributors != null && (
-                  <span
-                    title={t("contributors")}
-                    className="flex items-center gap-1 text-xs text-muted-foreground tabular-nums"
-                  >
-                    <Users className="size-3.5" />
-                    {plugin.contributors.toLocaleString("en-US")}
-                    {plugin.contributorGrowth != null &&
-                      plugin.contributorGrowth > 0 && (
-                        <span className="font-medium text-emerald-600 dark:text-emerald-400">
-                          +{plugin.contributorGrowth.toLocaleString("en-US")}
-                        </span>
-                      )}
-                  </span>
-                )}
-              </div>
-              {(plugin.isOfficial || plugin.isFeatured || plugin.isInsider || plugin.archived) && (
-                <div className="flex flex-wrap gap-1.5">
-                  {plugin.isOfficial && (
-                    <Badge className="w-fit bg-sky-600 text-white dark:bg-sky-500">
-                      🏛 {t("official")}
-                    </Badge>
-                  )}
-                  {plugin.isFeatured && (
-                    <Badge className="bg-gradient-brand w-fit text-white">
-                      ✨ {t("featured")}
-                    </Badge>
-                  )}
-                  {plugin.isInsider && (
-                    <Badge variant="secondary" className="w-fit">
-                      {t("insider")}
-                    </Badge>
-                  )}
-                  {plugin.archived && (
-                    <Badge variant="outline" className="w-fit">
-                      {t("archived")}
-                    </Badge>
-                  )}
-                </div>
-              )}
-              {/* 描述长度差异极大（有的仓库写了整段中英双语），截断三行才排得齐 */}
-              <CardDescription className="line-clamp-3 text-sm leading-snug">
-                {i18nDescriptions[plugin.fullName]?.[locale] ??
-                  (localizePluginDescription(
-                    plugin.fullName,
-                    locale,
-                    plugin.description,
-                  ) ||
-                    t("noDesc"))}
-              </CardDescription>
-            </CardHeader>
-            <CardContent className="mt-auto">
-              {(plugin.category || plugin.tags.length > 0) && (
-                <div className="flex flex-wrap gap-1.5">
-                  {plugin.category && (
-                    <Badge variant="outline" className="text-[11px]">
-                      {t(`categories.${plugin.category}`)}
-                    </Badge>
-                  )}
-                  {plugin.tags.slice(0, 4).map((tag) => (
-                    <Badge key={tag} variant="ghost" className="text-[11px]">
-                      #{tag}
-                    </Badge>
-                  ))}
-                </div>
-              )}
-              <div className="mt-4 flex items-center justify-between border-t border-border/60 pt-4">
-                <span
-                  title={t("updated")}
-                  className="text-xs text-muted-foreground"
-                >
-                  {plugin.language || "-"} · {day(plugin.pushedAt)}
-                </span>
-                <Button asChild size="sm" className="rounded-lg">
-                  <Link href={`/plugins/${plugin.fullName}`}>
-                    <FolderGit2 />
-                    {t("viewDetail")}
-                  </Link>
-                </Button>
-              </div>
-            </CardContent>
-          </Card>
-        ))}
-      </div>
-
-      {visible.length === 0 && (
+      {/* 插件网格：挂载前渲染首屏少量卡片（SSR 友好），挂载后切换为窗口虚拟滚动 */}
+      {visible.length === 0 ? (
         <p className="mt-10 text-center text-muted-foreground">
           {t("noResults")}
         </p>
+      ) : !mounted ? (
+        <div className="mt-6 grid gap-5 sm:grid-cols-2 lg:grid-cols-3">
+          {visible.slice(0, SSR_PREVIEW).map((plugin) => (
+            <PluginCard
+              key={plugin.fullName}
+              plugin={plugin}
+              i18nDescriptions={i18nDescriptions}
+            />
+          ))}
+        </div>
+      ) : (
+        <VirtualizedPluginGrid
+          visible={visible}
+          i18nDescriptions={i18nDescriptions}
+        />
       )}
     </div>
   );
 }
+
+/**
+ * 窗口级虚拟滚动的插件网格。
+ * 按当前列数把 visible 切成行，每行一个 measured 的绝对定位容器，
+ * 只有落在视口附近的行才会被渲染——2000+ 卡片也不会卡。
+ */
+function VirtualizedPluginGrid({
+  visible,
+  i18nDescriptions,
+}: {
+  visible: PluginWithGrowth[];
+  i18nDescriptions: Record<string, Record<string, string>>;
+}) {
+  // 列数跟随 Tailwind 的 sm/lg 视口断点（640/1024），用 matchMedia 保证与 CSS 完全对齐。
+  const [columnCount, setColumnCount] = React.useState(3);
+  React.useEffect(() => {
+    const lg = window.matchMedia("(min-width: 1024px)");
+    const sm = window.matchMedia("(min-width: 640px)");
+    const update = () =>
+      setColumnCount(lg.matches ? 3 : sm.matches ? 2 : 1);
+    update();
+    lg.addEventListener("change", update);
+    sm.addEventListener("change", update);
+    return () => {
+      lg.removeEventListener("change", update);
+      sm.removeEventListener("change", update);
+    };
+  }, []);
+
+  const rows = React.useMemo(() => {
+    const out: PluginWithGrowth[][] = [];
+    for (let i = 0; i < visible.length; i += columnCount) {
+      out.push(visible.slice(i, i + columnCount));
+    }
+    return out;
+  }, [visible, columnCount]);
+
+  const rowVirtualizer = useWindowVirtualizer({
+    count: rows.length,
+    estimateSize: () => ROW_ESTIMATE,
+    overscan: 4,
+  });
+
+  return (
+    <div
+      className="mt-6 w-full"
+      style={{
+        height: `${rowVirtualizer.getTotalSize()}px`,
+        position: "relative",
+      }}
+    >
+      {rowVirtualizer.getVirtualItems().map((virtualRow) => {
+        const row = rows[virtualRow.index];
+        return (
+          <div
+            key={virtualRow.key}
+            data-index={virtualRow.index}
+            ref={rowVirtualizer.measureElement}
+            className="grid gap-5 pb-5"
+            style={{
+              position: "absolute",
+              top: 0,
+              left: 0,
+              width: "100%",
+              transform: `translateY(${virtualRow.start}px)`,
+              gridTemplateColumns: `repeat(${columnCount}, minmax(0, 1fr))`,
+            }}
+          >
+            {row.map((plugin) => (
+              <PluginCard
+                key={plugin.fullName}
+                plugin={plugin}
+                i18nDescriptions={i18nDescriptions}
+              />
+            ))}
+          </div>
+        );
+      })}
+    </div>
+  );
+}
+
+const PluginCard = React.memo(function PluginCard({
+  plugin,
+  i18nDescriptions,
+}: {
+  plugin: PluginWithGrowth;
+  i18nDescriptions: Record<string, Record<string, string>>;
+}) {
+  const t = useTranslations("Plugins");
+  const locale = useLocale();
+  return (
+    <Card
+      className={`flex flex-col ${
+        plugin.isFeatured
+          ? "border-brand-500/50 bg-gradient-to-br from-brand-500/8 to-transparent"
+          : ""
+      }`}
+    >
+      <CardHeader className="pb-2">
+        <div className="flex items-start justify-between gap-2">
+          <CardTitle className="flex items-center gap-1.5 font-mono text-sm font-semibold break-all">
+            <Link
+              href={`/plugins/${plugin.fullName}`}
+              className="underline-offset-4 hover:text-brand-600 hover:underline dark:hover:text-brand-300"
+            >
+              {plugin.name}
+            </Link>
+            <ScoreBadge score={plugin.score} />
+          </CardTitle>
+          <span className="flex shrink-0 items-center gap-1 text-xs text-muted-foreground tabular-nums">
+            <Star className="size-3.5 fill-amber-400 text-amber-400" />
+            {plugin.stars.toLocaleString("en-US")}
+            {plugin.starGrowth > 0 && (
+              <span
+                title={t("weeklyGrowth")}
+                className="font-medium text-emerald-600 dark:text-emerald-400"
+              >
+                +{plugin.starGrowth.toLocaleString("en-US")}
+              </span>
+            )}
+          </span>
+        </div>
+        <div className="flex items-center gap-3">
+          <a
+            href={`https://github.com/${plugin.owner}`}
+            target="_blank"
+            rel="noopener"
+            className="w-fit text-xs text-muted-foreground underline-offset-4 hover:text-foreground hover:underline"
+          >
+            @{plugin.owner}
+          </a>
+          {plugin.contributors != null && (
+            <span
+              title={t("contributors")}
+              className="flex items-center gap-1 text-xs text-muted-foreground tabular-nums"
+            >
+              <Users className="size-3.5" />
+              {plugin.contributors.toLocaleString("en-US")}
+              {plugin.contributorGrowth != null &&
+                plugin.contributorGrowth > 0 && (
+                  <span className="font-medium text-emerald-600 dark:text-emerald-400">
+                    +{plugin.contributorGrowth.toLocaleString("en-US")}
+                  </span>
+                )}
+            </span>
+          )}
+        </div>
+        {(plugin.isOfficial || plugin.isFeatured || plugin.isInsider || plugin.archived) && (
+          <div className="flex flex-wrap gap-1.5">
+            {plugin.isOfficial && (
+              <Badge className="w-fit bg-sky-600 text-white dark:bg-sky-500">
+                🏛 {t("official")}
+              </Badge>
+            )}
+            {plugin.isFeatured && (
+              <Badge className="bg-gradient-brand w-fit text-white">
+                ✨ {t("featured")}
+              </Badge>
+            )}
+            {plugin.isInsider && (
+              <Badge variant="secondary" className="w-fit">
+                {t("insider")}
+              </Badge>
+            )}
+            {plugin.archived && (
+              <Badge variant="outline" className="w-fit">
+                {t("archived")}
+              </Badge>
+            )}
+          </div>
+        )}
+        {/* 描述长度差异极大（有的仓库写了整段中英双语），截断三行才排得齐 */}
+        <CardDescription className="line-clamp-3 text-sm leading-snug">
+          {i18nDescriptions[plugin.fullName]?.[locale] ??
+            (localizePluginDescription(
+              plugin.fullName,
+              locale,
+              plugin.description,
+            ) ||
+              t("noDesc"))}
+        </CardDescription>
+      </CardHeader>
+      <CardContent className="mt-auto">
+        {(plugin.category || plugin.tags.length > 0) && (
+          <div className="flex flex-wrap gap-1.5">
+            {plugin.category && (
+              <Badge variant="outline" className="text-[11px]">
+                {t(`categories.${plugin.category}`)}
+              </Badge>
+            )}
+            {plugin.tags.slice(0, 4).map((tag) => (
+              <Badge key={tag} variant="ghost" className="text-[11px]">
+                #{tag}
+              </Badge>
+            ))}
+          </div>
+        )}
+        <div className="mt-4 flex items-center justify-between border-t border-border/60 pt-4">
+          <span
+            title={t("updated")}
+            className="text-xs text-muted-foreground"
+          >
+            {plugin.language || "-"} · {day(plugin.pushedAt)}
+          </span>
+          <Button asChild size="sm" className="rounded-lg">
+            <Link href={`/plugins/${plugin.fullName}`}>
+              <FolderGit2 />
+              {t("viewDetail")}
+            </Link>
+          </Button>
+        </div>
+      </CardContent>
+    </Card>
+  );
+});


### PR DESCRIPTION
## 改了什么

### 1. `/{locale}/plugins` 页面加虚拟滚动

**问题**：插件超市页有 4000+ 个插件卡片，全量渲染导致 DOM 超过 2000 个元素，搜索和滚动巨卡，甚至直接让浏览器未响应。

**方案**：
- 安装 [`@tanstack/react-virtual`](https://tanstack.com/virtual)（`useWindowVirtualizer`），按行虚拟化插件网格
- 卡片抽成 `React.memo` 的 `PluginCard` 组件，避免不必要重渲染
- 用 `matchMedia` 跟随 Tailwind 的 sm/lg 断点切 1/2/3 列，`measureElement` 测真实行高
- 挂载前渲染 24 张首屏卡片（SSR 友好、无 hydration 不一致），挂载后切虚拟列表

**实测**：4093 个插件只渲染 ~21 张卡片，搜索「sidebar」筛到 74 条也只渲染 21 张——滚动与搜索均流畅。

### 2. 加可爱的 404 页面

- 新增 `src/components/not-found-content.tsx`：漂浮的鲸鱼吉祥物（`animate-float`）+ 渐变大字 404 + 文案 + 两个导航按钮（返回首页 / 逛逛插件超市）
- `src/app/not-found.tsx`（根 404，处理未匹配 URL）：自包含 `ThemeProvider` + `NextIntlClientProvider`，从 next-intl 中间件写入的 `X-NEXT-INTL-LOCALE` 头检测语言，回退到 `NEXT_LOCALE` cookie 再回退默认语言
- `src/app/[locale]/not-found.tsx`（segment 404，处理 `notFound()` 调用，如插件详情页找不到仓库）：复用同一组件，由 `[locale]` layout 包裹（带站点 header/footer）
- `src/app/globals.css` 加 `float` 关键帧，并在 `prefers-reduced-motion` 下禁用
- 四语言文案（zh/en/ja/ko）加到 `messages/*.json` 的 `NotFound` 命名空间

## 验证

- `pnpm exec tsc --noEmit` 通过
- `pnpm run build` 成功
- 浏览器实测：zh/en 404 文案正确、插件详情 notFound 带 header/footer、虚拟滚动滚动回收正常
