### PR TITLE
Add kiligzzz dsh plugins to MANUAL_REPOS

### DIFF
--- a/scripts/sync-plugins-db.mjs
+++ b/scripts/sync-plugins-db.mjs
@@ -54,6 +54,11 @@ const MANUAL_REPOS = [
   // 改名前叫 huiliyi37/dsh-tianshu-build，新名只挂 dsh / dsh-harness，topic 搜索抓不到；
   // 旧名下的评分 64 与 star 历史等它进库后用 scripts/rename-plugin.mjs 迁过去
   "huiliyi37/oh-my-tianshu",
+  // 2026-08-19~21 洪峰期（窗口 2152/1791 > search 上限 1000）二分截断漏掉，
+  // topic 搜索已能抓到（可见于 created 窗口查询），进手动名单兜底防软删
+  "kiligzzz/dsh-session-archive",
+  "kiligzzz/dsh-session-nav",
+  "kiligzzz/dsh-capability-manager",
 ];
 
 // ---------- 凭据 ----------


### PR DESCRIPTION
## 背景

2026-08-19~21 生态洪峰期，`topic:dsh-plugin+is:public+created:2026-08-19..2026-08-22` 窗口结果 2152/1791 个，远超 GitHub search API 单查询 1000 上限。`sync-plugins-db.mjs` 的二分递归虽按秒切分，但实测这三个仓库未入库（API 列表无记录）。

## 验证

- topic 搜索能抓到（created 窗口查询返回 `kiligzzz/dsh-session-nav` 等）
- 同批次其他仓库（如 Anionex/dsh-vision-toolkit、bowenliang123/dsh-context）已在库

## 修复

将三个仓库加入 `MANUAL_REPOS` 手动名单，每轮逐仓库抓取入库并免于「摘 topic 软删」：

- `kiligzzz/dsh-session-archive`（2026-08-19 创建）
- `kiligzzz/dsh-session-nav`（2026-08-20 创建）
- `kiligzzz/dsh-capability-manager`（2026-08-21 创建）