### PR TITLE
Add jo32 reader plugins to MANUAL_REPOS

### DIFF
--- a/scripts/sync-plugins-db.mjs
+++ b/scripts/sync-plugins-db.mjs
@@ -41,6 +41,9 @@ const MANUAL_REPOS = [
   "CocoSgt/dsh-skills",
   "CocoSgt/dsh-attachments",
   "omdsh-dev/dsh-office",
+  // 2026-08 topic sync 连续超时期间创建，尚未进入索引
+  "jo32/dsh-hackernews-reader",
+  "jo32/dsh-nga-reader",
 ];
 
 // ---------- 凭据 ----------


### PR DESCRIPTION
## 背景

以下两个公开仓库已添加 `dsh-plugin` topic，但当前 dshfind API 均返回 `404 plugin not found`：

- `jo32/dsh-hackernews-reader`
- `jo32/dsh-nga-reader`

`Sync plugins to Turso` 定时任务自 2026-08-16 起连续在 `pnpm sync:db` 达到 20 分钟上限后取消，新仓库因此没有进入索引。

## 修改

将两个仓库加入 `MANUAL_REPOS`，使同步恢复后可逐仓库补抓并避免软删。

## 验证

- `node --check scripts/sync-plugins-db.mjs`
- `git diff --check`

Closes #17