### PR TITLE
Replace R2 ISR page storage with native Workers Cache

### DIFF
--- a/custom-worker.mjs
+++ b/custom-worker.mjs
@@ -1,0 +1,31 @@
+import handler from "./.open-next/worker.js";
+import { applyPageCachePolicy, cacheTtl } from "./scripts/lib/page-cache-policy.mjs";
+
+export default {
+  async fetch(request, env, ctx) {
+    const path = new URL(request.url).pathname;
+    // The isolated pilot exposes only the selected pages and their static assets.
+    if (env.NATIVE_PAGE_CACHE_PHASE === "canary" &&
+        !cacheTtl(path, "canary") && !path.startsWith("/_next/") &&
+        !/\.(?:svg|png|jpg|ico|woff2?)$/.test(path)) {
+      return new Response("Not found", {
+        status: 404, headers: { "Cache-Control": "private, no-store" },
+      });
+    }
+    const start = Date.now();
+    let response = await handler.fetch(request, env, ctx);
+    if (env.NATIVE_CACHE_DIAGNOSTICS === "1") {
+      // Pilot only: finish the body before timing; this is wall time, NOT CPU.
+      response = new Response(response.body === null ? null : await response.arrayBuffer(), response);
+      response.headers.set("x-dshfind-render-id", crypto.randomUUID());
+      response.headers.set("x-dshfind-render-wall-ms", String(Date.now() - start));
+      response.headers.set("x-robots-tag", "noindex");
+      console.log(JSON.stringify({ event: "native-page-render", path,
+        status: response.status, wallMs: Date.now() - start }));
+    }
+    return applyPageCachePolicy(request, response, env);
+  },
+};
+
+// Retain the deployed class during the migration/rollback observation window.
+export { DOQueueHandler } from "./.open-next/worker.js";

--- a/docs/native-page-cache.md
+++ b/docs/native-page-cache.md
@@ -27,6 +27,7 @@
 - 冷/混合实例请求的 CPU 最高 **1639 ms**；本地 CPU 采样主要指向模块初始化。暖渲染结果不能代表首次冷启动。
 - 全量构建：562 个预渲染页面，定时 ISR 条目为 0；617 个静态资产文件，总约 751 MiB、单文件最大 2.39 MiB。资产由 Cloudflare 管理，不写入 R2。
 - 单元测试 124/124 通过；类型检查通过；Lint 0 错误（已有 warning 保留）。
+- 完整无 R2 预览版本 `608d7e67-afd2-4e45-ad2f-a1d1b0b53f61`：29/29 页面、接口与真实 HTTP 404 检查通过；静态首页到动态插件目录客户端导航通过。
 
 ## 48 小时观察
 
@@ -50,7 +51,7 @@ CLOUDFLARE_ACCOUNT_ID=8f19bebe359e4ec1a24c68c5f49c1584 pnpm exec wrangler rollba
 
 ## 构建与费用边界
 
-常规 `pnpm cf:deploy` 会让 OpenNext 将预渲染数据复制到静态资产再部署，不能省略 populateCache 步骤后直接部署一个刚构建的目录。独立验证配置为 `wrangler.canary.jsonc`，诊断响应带 noindex。
+`pnpm cf:build` 会在构建后执行 `populateCache local`，把预渲染数据复制到静态资产；这是为了兼容现有 Workers Builds 的 `pnpm run cf:build` + `npx wrangler deploy` 发布流水线。常规 `pnpm cf:deploy` 也会通过 OpenNext 完成填充。不要绕过这些命令后直接部署缺少预渲染资产的目录。独立验证配置为 `wrangler.canary.jsonc`，诊断响应带 noindex。
 
 原生 Workers Cache 命中跳过 Worker 代码执行，但请求仍按 Workers 请求计费，包括启用该缓存后的静态资产请求。Standard 套餐每月含 1000 万请求、3000 万 CPU ms，超额 CPU 为 $0.02/百万 ms；实际额度与账号其他 Worker 共用。缓存不会保证零费用。
 

--- a/docs/native-page-cache.md
+++ b/docs/native-page-cache.md
@@ -1,0 +1,57 @@
+# 页面缓存迁移与观察
+
+2026-09-08：保留 Next.js/OpenNext，改用 Workers Cache + 只读 Static Assets。
+
+## 当前设计
+
+- 首页、课程、分类、语言、分页目录、浏览页和文档目录：构建快照，只读静态资产，不定时重建。
+- 插件详情、插件目录、标签、文档正文：缓存未命中时请求渲染，公开 HTML/RSC 边缘缓存一小时。
+- 论坛列表和帖子：SSR 保留可索引正文，公开响应缓存 60 秒，浏览器继续刷新回复。
+- 全量插件 JSON：边缘缓存 30 分钟；sitemap 一小时。徽标、分享卡和搜索建议保留原有公开响应 TTL。
+- 登录、会话、带凭据、未知 Cookie、修改请求、Set-Cookie 与错误响应不进入共享缓存。只有显式语言 URL 上单个有效 NEXT_LOCALE 偏好 Cookie 可缓存。
+- HTML/RSC、路由导航请求、Host、Cookie 等通过 Vary 隔离；部署版本间不共享缓存。
+- 新应用不再绑定 R2，不使用 ISR 队列。历史 DO 类迁移与导出保留，便于回滚。
+
+`dshfind-isr-cache` 桶及已有对象全部保留。此次迁移不包含删除对象、删除桶、设置生命周期或删除 DO 数据。
+
+## 验证记录
+
+三页面试点版本：`0426a95b-e220-4d04-ac25-c75b437e0ba0`。
+
+- 55 次低流量请求验证公开 HTML 命中、相同渲染 ID/内容复用，以及 session/Authorization 绕过。
+- 浏览器英文到中文导航成功；重放真实 RSC 请求得到 200 text/x-component，MISS 后 HIT，ID 和内容一致。
+- 同一连接上的缓存 HIT：11 个暖样本，TTFB P50 **205 ms**、P95 **254 ms**。
+- 同条件现网对照：11 个暖样本，TTFB P50 **360 ms**、P95 **2181 ms**。
+- 连续未缓存暖渲染：24 个样本，Cloudflare 日志实际 CPU P50 **33 ms**、P95 **64 ms**、最大 **94 ms**；服务端 wall-time P95 **613 ms**。
+- 以上来自本次测试网络的欧洲出口，不代表所有地区。每次新建连接的数据含显著 TLS/网络延迟，不与复用连接混算。
+- 冷/混合实例请求的 CPU 最高 **1639 ms**；本地 CPU 采样主要指向模块初始化。暖渲染结果不能代表首次冷启动。
+- 全量构建：562 个预渲染页面，定时 ISR 条目为 0；617 个静态资产文件，总约 751 MiB、单文件最大 2.39 MiB。资产由 Cloudflare 管理，不写入 R2。
+- 单元测试 124/124 通过；类型检查通过；Lint 0 错误（已有 warning 保留）。
+
+## 48 小时观察
+
+观察窗口从正式版本发布完成开始。需要结合实际页面请求数与爬虫量判断，1000 用户不等于 1000 请求。
+
+1. 正式站首页、插件详情、目录、论坛、文档及语言切换是否正常；错误率是否升高。
+2. Worker 的 Cache 命中率、CPU 分位数与 CPU 总量；单独注意冷启动和大量不同 URL 的爬虫。
+3. R2 对象数和容量是否停止随日常访问、后续部署持续增长。平台统计有延迟；旧数据仍然占用存储。
+4. 内容刷新：公开内容通常最多滞后一小时，论坛 60 秒；部署会隔离新旧缓存。
+5. 观察通过后，再单独决定是否删除旧 R2 数据。删除后，依赖该桶的旧版本将不再具有完整回滚条件。
+
+## 回滚
+
+迁移前正式 Worker 版本：`070cfdce-aa1b-4e02-93e0-bfc886381f66`（2026-09-08 08:58 UTC）。
+
+```sh
+CLOUDFLARE_ACCOUNT_ID=8f19bebe359e4ec1a24c68c5f49c1584 pnpm exec wrangler rollback 070cfdce-aa1b-4e02-93e0-bfc886381f66 --name dshfind -y
+```
+
+回滚需要同时恢复仓库中的旧缓存配置，否则下一次 Workers Builds 会再次部署新配置。不要删除桶后再尝试这个旧版本。
+
+## 构建与费用边界
+
+常规 `pnpm cf:deploy` 会让 OpenNext 将预渲染数据复制到静态资产再部署，不能省略 populateCache 步骤后直接部署一个刚构建的目录。独立验证配置为 `wrangler.canary.jsonc`，诊断响应带 noindex。
+
+原生 Workers Cache 命中跳过 Worker 代码执行，但请求仍按 Workers 请求计费，包括启用该缓存后的静态资产请求。Standard 套餐每月含 1000 万请求、3000 万 CPU ms，超额 CPU 为 $0.02/百万 ms；实际额度与账号其他 Worker 共用。缓存不会保证零费用。
+
+官方依据：[Workers Cache](https://developers.cloudflare.com/workers/cache/)、[Workers 定价](https://developers.cloudflare.com/workers/platform/pricing/)、[OpenNext 缓存](https://opennext.js.org/cloudflare/caching)。

--- a/docs/r2-cache-audit-2026-09-08.md
+++ b/docs/r2-cache-audit-2026-09-08.md
@@ -1,0 +1,46 @@
+# R2 缓存核对（2026-09-08）
+
+## 已确认的线上事实
+
+- 账户：`8f19bebe359e4ec1a24c68c5f49c1584`；桶：`dshfind-isr-cache`。
+- 控制台显示约 584,500 个对象、300.13 GB（指标有延迟，非全量清单的精确汇总）。
+- `incremental-cache/` 下通过四页目录核对到 87 个不同 build ID。
+- 公开主站 `/zh` 的 RSC 数据包含当前 build ID：`eVDjMunbHD_ELyQk9MlU6`；该目录样本在 9 月 8 日持续更新。操作前必须重新核对在线版本，不能把本文的 ID 当成永久有效的保留名单。
+- Wrangler 查询的桶生命周期只有 `Default Multipart Abort Rule`，7 天后终止未完成分片上传；没有对已完成对象的过期删除规则。
+- 非当前目录 `0dkoT739bIbhumKDg53z8` 的对象样本修改时间为 8 月 22 日，且存在与当前目录相同哈希的页面对象。
+- 当前目录之外的 86 个目录不能直接全部视为可删：还需排除回滚版本、预览或其他仍在使用此桶的部署。
+
+## 缓存内容与体积实测
+
+使用 Wrangler 正常认证，只读下载当前 build 的三个对象；没有提取现有认证令牌。
+
+| 路径（由缓存 HTML canonical 确认） | 对象大小（字节） | 离线 gzip 大小（字节） |
+| --- | ---: | ---: |
+| `/en/plugins/TellToday/dsh-narrative-voice` | 332496 | 76928 |
+| `/en/plugins/fuzz1og/dsh-ocgo-quota` | 459014 | 91157 |
+| `/en/plugins/all/24` | 1935521 | 216711 |
+
+三个对象均为 `type: app`，同时包含 HTML、RSC、segmentData 和元数据。大对象是分页索引，不是未知上传。样本不足以估计全桶 404 占比或可释放的总字节数。
+
+离线压缩仅说明冗余较多，不代表已启用压缩，也不代表压缩一定降低总费用。需同步实现缓存读写兼容，并测量 Worker 解压 CPU、延迟和峰值内存；不能只改变对象 Content-Encoding。
+
+## 修复方向与边界
+
+1. 保留现有 ISR，先统计每个 build 的对象数量、总字节数、最早和最晚写入日期，识别仍服务流量的部署与回滚窗口。
+2. 仅对明确退役的 build 前缀添加清理规则；不对整个 `incremental-cache/` 盲目添加短期过期规则。后者会删除当前 build 的冷门或构建期页面，而这些页面的缺失重建行为尚未验证。
+3. 后续部署流程应记录 Next build ID 与 Worker version ID 的对应关系，部署验收成功后为退役 build 安排延迟清理；回滚前取消该 build 的清理规则。Next build ID 与 Worker version UUID 不是同一种标识。
+4. 404 路径缓存、压缩、索引页大小和纯静态部署分别评估，不能根据三个正常页面样本断言其收益。
+
+## 当前执行状态
+
+- 完成控制台目录核对、生命周期读取、当前 build 识别、三个对象内容与压缩采样。
+- 本地修正三处把 Cloudflare ISR 描述为“零函数调用”的注释，未部署。
+- 尚未删除 R2 对象、修改生命周期或部署主站修复。
+- 临时只读远程诊断被自动审批拒绝（远程 Worker 的元数据暴露风险）。后续用户已授权，但改为缓存迁移试点，未启动该诊断；临时文件位于 `/tmp/dshfind-r2-audit`，无删除或写入 R2 的代码。
+
+## 参考
+
+- [OpenNext 缓存](https://opennext.js.org/cloudflare/caching)
+- [Cloudflare R2 生命周期](https://developers.cloudflare.com/r2/buckets/object-lifecycles/)
+- [R2 定价](https://developers.cloudflare.com/r2/pricing/)
+- [Workers 定价](https://developers.cloudflare.com/workers/platform/pricing/)

--- a/docs/superpowers/plans/2026-09-08-native-page-cache.md
+++ b/docs/superpowers/plans/2026-09-08-native-page-cache.md
@@ -14,7 +14,7 @@
 - [x] Measure repeated requests and Cloudflare CPU observations. Require correct pages and no failures, warmed HIT without rendering, p95 HIT TTFB <1s from this test location, warmed uncached render p95 <2s and CPU p95 <100ms. Report sample size/location and do not equate TTFB with CPU. If CPU cannot be observed or limits fail, investigate before production expansion.
 - [x] After pilot passes, remove timed revalidation: snapshot category/language/index/browse/docs-index pages become build-only, database details/catalogue/forum/document pages request-rendered. Remove fetch persistence in forum helpers. Stop unbounded catch-all ISR. Ensure non-prebuilt tag pages remain renderable.
 - [x] Replace R2 incremental adapter with read-only Static Assets; remove active R2 binding and queue use while retaining existing DO class exports/migrations for rollback. Enable version-isolated Workers Cache. Do not delete the R2 bucket or DO data.
-- [ ] Run typecheck, lint, tests, OpenNext build, preview smoke and browser client-navigation verification. Confirm artifact file count within platform limits and cache manifests have no timed regeneration.
+- [x] Run typecheck, lint, tests, OpenNext build, preview smoke and browser client-navigation verification. Confirm artifact file count within platform limits and cache manifests have no timed regeneration.
 - [ ] Deploy production, record previous version, smoke public/private/static/unknown routes and observe CPU/cache status. Roll back immediately if functional checks fail.
 - [ ] Record before/after samples, deployment IDs, 48-hour observation checklist and rollback command. Keep all existing R2 data until user separately decides on deletion.
 
@@ -26,3 +26,5 @@
 - Controlled warm uncached series: n=24, actual Wrangler tail CPU p50=33ms / p95=64ms / max=94ms; wall-time p95=613ms. Warm CPU and latency gates passed.
 - Cold/mixed-isolate misses were significantly higher (up to 1639ms CPU); local CPU profiling identified module initialization as the primary cold overhead. They are recorded separately and are NOT represented by warm numbers. Native HIT skips rendering; observe cold fraction and bots over 48 hours.
 - Browser language-switch navigation from English to Chinese passed.
+
+Workers Builds settings verified: build=`pnpm run cf:build`, deploy=`npx wrangler deploy`, branch=main. cf:build now explicitly calls populateCache local so the automatic deployment includes read-only page assets.

--- a/docs/superpowers/plans/2026-09-08-native-page-cache.md
+++ b/docs/superpowers/plans/2026-09-08-native-page-cache.md
@@ -1,0 +1,28 @@
+# Native page cache migration implementation plan
+
+**Goal:** Validate a small Cloudflare Workers Cache pilot, migrate only after it passes, and preserve the R2 bucket and data for the user's 48-hour observation.
+
+**Architecture:** Keep Next.js/OpenNext. Compile snapshot-only routes into the read-only Static Assets incremental store. Render database-backed pages on native cache misses. An explicit Worker response policy selects public routes and differentiates HTML/RSC, language, host and cookie variants. Private routes, credentials, Set-Cookie, errors and mutations never enter shared response cache. Production deployment cache remains version-isolated.
+
+**Execution:** Apply writing-plans and test-driven-development; independently implement/review cache policy under subagent-driven-development. No deletion commands or lifecycle changes are part of this plan.
+
+- [x] Fetch production source and create `codex/native-page-cache`, carrying only this task's earlier audit/comment edits.
+- [x] Verify baseline with `node --test scripts/lib/*.test.mjs` and record existing failures separately.
+- [x] Implement `scripts/lib/page-cache-policy.mjs` using failing node:test cases first. Preserve existing Vary and include Cookie, Host, RSC and router negotiation headers. Use browser max-age=0 and edge TTL 3600 for public content, 60 for forum, 1800 for catalogue API; bypass all unknown/private paths and unsuccessful responses.
+- [x] Add a custom Worker using the generated OpenNext fetch handler and the policy. Canary phase permits caching only three explicit plugin-detail URLs. Preserve DO exports during pilot for rollback compatibility.
+- [x] Make the detail route request-rendered in the isolated Worker, exposing only three selected URLs. Conditional `connection()` caused DYNAMIC_SERVER_USAGE and was replaced by route-wide revalidate=0 before validation. Build and deploy the isolated canary without populating or deleting the production R2 cache. Verify content/canonicals, language, HTML and RSC navigation, cache hit, credentials bypass and response sizes.
+- [x] Measure repeated requests and Cloudflare CPU observations. Require correct pages and no failures, warmed HIT without rendering, p95 HIT TTFB <1s from this test location, warmed uncached render p95 <2s and CPU p95 <100ms. Report sample size/location and do not equate TTFB with CPU. If CPU cannot be observed or limits fail, investigate before production expansion.
+- [x] After pilot passes, remove timed revalidation: snapshot category/language/index/browse/docs-index pages become build-only, database details/catalogue/forum/document pages request-rendered. Remove fetch persistence in forum helpers. Stop unbounded catch-all ISR. Ensure non-prebuilt tag pages remain renderable.
+- [x] Replace R2 incremental adapter with read-only Static Assets; remove active R2 binding and queue use while retaining existing DO class exports/migrations for rollback. Enable version-isolated Workers Cache. Do not delete the R2 bucket or DO data.
+- [ ] Run typecheck, lint, tests, OpenNext build, preview smoke and browser client-navigation verification. Confirm artifact file count within platform limits and cache manifests have no timed regeneration.
+- [ ] Deploy production, record previous version, smoke public/private/static/unknown routes and observe CPU/cache status. Roll back immediately if functional checks fail.
+- [ ] Record before/after samples, deployment IDs, 48-hour observation checklist and rollback command. Keep all existing R2 data until user separately decides on deletion.
+
+## Pilot evidence
+
+- Working pilot version: `0426a95b-e220-4d04-ac25-c75b437e0ba0`.
+- 55 low-rate requests: all selected HTML pages correct; repeated anonymous/locale-cookie responses HIT with identical render IDs; session and Authorization bypass. Bare RSC requests correctly redirect to a hashed URL, so navigation was additionally validated using a real browser-generated RSC request (200 text/x-component, MISS then HIT with same ID/body).
+- Reused-connection HIT samples: n=11, TTFB p50=205ms / p95=254ms. Same-location existing production comparison: n=11, p50=360ms / p95=2181ms. Network exits were European Cloudflare locations; not a worldwide latency guarantee.
+- Controlled warm uncached series: n=24, actual Wrangler tail CPU p50=33ms / p95=64ms / max=94ms; wall-time p95=613ms. Warm CPU and latency gates passed.
+- Cold/mixed-isolate misses were significantly higher (up to 1639ms CPU); local CPU profiling identified module initialization as the primary cold overhead. They are recorded separately and are NOT represented by warm numbers. Native HIT skips rendering; observe cold fraction and bots over 48 hours.
+- Browser language-switch navigation from English to Chinese passed.

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -12,8 +12,14 @@ const eslintConfig = defineConfig([
     "out/**",
     "build/**",
     "next-env.d.ts",
+    ".open-next/**",
+    ".wrangler/**",
+    ".pnpm-store/**",
+    "workers/api-edge/assets/**",
+    "workers/api-edge/.wrangler/**",
   ]),
   {
+    files: ["**/*.{js,jsx,mjs,ts,tsx,mts,cts}"],
     rules: {
       // 这些客户端组件有意在 hydration 后读取 localStorage、主题或浏览器 cookie。
       // React Compiler 的规则继续作为 warning 保留可见性，但不能让现有 SSR 防闪烁

--- a/open-next.config.ts
+++ b/open-next.config.ts
@@ -1,19 +1,9 @@
 import { defineCloudflareConfig } from "@opennextjs/cloudflare";
-import r2IncrementalCache from "@opennextjs/cloudflare/overrides/incremental-cache/r2-incremental-cache";
-import doQueue from "@opennextjs/cloudflare/overrides/queue/do-queue";
+import staticAssetsIncrementalCache from "@opennextjs/cloudflare/overrides/incremental-cache/static-assets-incremental-cache";
 
-/**
- * OpenNext 的 Cloudflare Workers 适配配置。
- *
- * incrementalCache：ISR 产物存 R2（绑定 NEXT_INC_CACHE_R2_BUCKET）。
- *   /plugins 1800s、插件详情页 86400s、/api/plugins-data 1800s 都靠它，
- *   否则每次重验证都要重新查 Turso 并重渲染。
- * queue：重验证去重。过期路径只放一个请求回源重建，其余先吃 stale。
- *
- * 没配 tagCache 是有意的——全站只用时间型 revalidate，
- * 没有任何 revalidateTag/revalidatePath 调用，装了纯属多一套 D1/DO 要维护。
- */
+// Build-only pages live in versioned, read-only Static Assets. Database-backed
+// routes use revalidate=0; custom-worker.mjs owns public HTTP response caching.
+// There is no ISR queue, persistent fetch cache, or R2 binding in this design.
 export default defineCloudflareConfig({
-  incrementalCache: r2IncrementalCache,
-  queue: doQueue,
+  incrementalCache: staticAssetsIncrementalCache,
 });

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "build": "next build",
     "start": "next start",
     "lint": "eslint",
-    "cf:build": "opennextjs-cloudflare build",
+    "cf:build": "opennextjs-cloudflare build && opennextjs-cloudflare populateCache local",
     "cf:preview": "opennextjs-cloudflare build && opennextjs-cloudflare preview",
     "cf:deploy": "opennextjs-cloudflare build && opennextjs-cloudflare deploy",
     "cf:typegen": "wrangler types --env-interface CloudflareEnv cloudflare-env.d.ts",

--- a/public/_headers
+++ b/public/_headers
@@ -1,0 +1,2 @@
+/_next/static/*
+  Cache-Control: public, max-age=31536000, immutable

--- a/scripts/lib/page-cache-policy.mjs
+++ b/scripts/lib/page-cache-policy.mjs
@@ -1,0 +1,95 @@
+const CANARY_PATHS = new Set([
+  '/en/plugins/TellToday/dsh-narrative-voice',
+  '/en/plugins/fuzz1og/dsh-ocgo-quota',
+  '/zh/plugins/fuzz1og/dsh-ocgo-quota',
+]);
+
+// Workers Cache looks up responses before the Worker executes. These fields
+// must segregate anonymous HTML, RSC and authenticated requests at that layer.
+const VARY_FIELDS = [
+  'Cookie', 'Host', 'X-Forwarded-Proto', 'Authorization', 'Next-Action', 'RSC',
+  'Next-Router-State-Tree', 'Next-Router-Prefetch',
+  'Next-Router-Segment-Prefetch', 'Next-Url',
+];
+
+export function cacheTtl(pathname, phase = 'all') {
+  if (phase === 'canary') return CANARY_PATHS.has(pathname) ? 3600 : 0;
+  if (phase !== 'all') return 0;
+  if (pathname === '/api/plugins-data') return 1800;
+  if (pathname === '/sitemap.xml' || /^\/sitemap\/[^/]+$/.test(pathname)) return 3600;
+
+  const locale = pathname.match(/^\/(?:zh|en|ja|ko)(\/.*)?$/);
+  if (!locale) return 0;
+  const path = locale[1] || '';
+  if (path === '/bbs' || /^\/bbs\/t\/[^/]+$/.test(path)) return 60;
+  if (path === '' || path === '/plugins' || path === '/plugins/browse') return 3600;
+  if (/^\/(?:docs|learn)(?:\/[^/]+)*$/.test(path)) return 3600;
+  if (/^\/plugins\/all\/[1-9]\d*$/.test(path)) return 3600;
+  if (/^\/plugins\/(?:c|t|lang)\/[^/]+$/.test(path)) return 3600;
+  // Reserved route prefixes must not fall through as owner/repo pairs.
+  if (/^\/plugins\/(?!all\/|c\/|t\/|lang\/)[^/]+\/[^/]+$/.test(path)) return 3600;
+  return 0;
+}
+
+function appropriateContentType(pathname, headers) {
+  const type = (headers.get('content-type') || '').split(';')[0].trim().toLowerCase();
+  if (pathname === '/api/plugins-data' || pathname === '/api/suggest') return type === 'application/json';
+  if (/^\/api\/(?:badge|card)\/[^/]+\/[^/]+$/.test(pathname)) return type === 'image/svg+xml';
+  if (pathname === '/sitemap.xml' || pathname.startsWith('/sitemap/')) {
+    return type === 'application/xml' || type === 'text/xml';
+  }
+  return type === 'text/html' || type === 'text/x-component';
+}
+
+export function applyPageCachePolicy(request, response, env = {}) {
+  const pathname = new URL(request.url).pathname;
+  const headers = new Headers(response.headers);
+  const vary = (headers.get('vary') || '').split(',').map(value => value.trim()).filter(Boolean);
+  const ttl = cacheTtl(pathname, env.NATIVE_PAGE_CACHE_PHASE ?? 'all');
+  const knownPublicApi = (env.NATIVE_PAGE_CACHE_PHASE ?? 'all') === 'all'
+    && (pathname === '/api/suggest' || /^\/api\/(?:badge|card)\/[^/]+\/[^/]+$/.test(pathname));
+  const upstreamControl = headers.get('cache-control') || '';
+  const upstreamDirectives = upstreamControl.toLowerCase().split(',').map(value => value.trim());
+  const preservePublicApi = knownPublicApi && upstreamDirectives.includes('public')
+    && !upstreamDirectives.some(value => /^(?:private|no-store|no-cache)(?:=|$)/.test(value));
+  // Explicit locale URLs determine page language. Permit only this single
+  // preference cookie; unknown, duplicate and session cookies stay private.
+  const cookie = request.headers.get('cookie');
+  const safeLocaleCookie = /^\/(?:zh|en|ja|ko)(?:\/|$)/.test(pathname)
+    && /^[\t ]*NEXT_LOCALE=(?:zh|en|ja|ko)[\t ]*$/.test(cookie ?? '');
+  const unsafe = env.AUTH_GATE === '1'
+    || !['GET', 'HEAD'].includes(request.method)
+    || (cookie !== null && !safeLocaleCookie)
+    || ['Authorization', 'Next-Action'].some(field => request.headers.has(field))
+    || response.status !== 200
+    || headers.has('set-cookie')
+    || vary.includes('*')
+    || !appropriateContentType(pathname, headers);
+
+  // Remove stale upstream CDN overrides so this single policy owns the TTL.
+  // Standard s-maxage is sufficient for native Workers Cache.
+  headers.delete('cdn-cache-control');
+  headers.delete('cloudflare-cdn-cache-control');
+  if ((!ttl && !preservePublicApi) || unsafe) {
+    const preserveSuggestNoStore = !unsafe && knownPublicApi && pathname === '/api/suggest'
+      && upstreamControl.trim().toLowerCase() === 'no-store';
+    headers.set('cache-control', preserveSuggestNoStore ? upstreamControl : 'private, no-store');
+    headers.set('x-dshfind-cache-policy', 'bypass');
+  } else {
+    const existing = new Set(vary.map(field => field.toLowerCase()));
+    for (const field of VARY_FIELDS) {
+      if (!existing.has(field.toLowerCase())) vary.push(field);
+    }
+    headers.set('vary', vary.join(', '));
+    headers.set('cache-control', preservePublicApi ? upstreamControl : `public, max-age=0, s-maxage=${ttl}, stale-while-revalidate=60`);
+    const publicTtl = preservePublicApi
+      ? upstreamControl.match(/(?:^|,)\s*s-maxage=(\d+)(?:\s*,|\s*$)/i)?.[1] ?? 'api'
+      : ttl;
+    headers.set('x-dshfind-cache-policy', `public-${publicTtl}`);
+  }
+  return new Response(response.body, {
+    status: response.status,
+    statusText: response.statusText,
+    headers,
+  });
+}

--- a/scripts/lib/page-cache-policy.test.mjs
+++ b/scripts/lib/page-cache-policy.test.mjs
@@ -1,0 +1,150 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import * as policy from './page-cache-policy.mjs';
+
+const page = '/en/plugins/TellToday/dsh-narrative-voice';
+const requiredVary = ['cookie', 'host', 'x-forwarded-proto', 'authorization', 'next-action', 'rsc', 'next-router-state-tree', 'next-router-prefetch', 'next-router-segment-prefetch', 'next-url'];
+function apply(path = page, requestInit = {}, responseInit = {}, env = {}) {
+  return policy.applyPageCachePolicy(new Request(`https://dshfind.com${path}`, requestInit), new Response('payload', {
+    ...responseInit,
+    headers: { 'content-type': 'text/html; charset=utf-8', ...responseInit.headers },
+  }), env);
+}
+function bypass(response) {
+  assert.equal(response.headers.get('cache-control'), 'private, no-store');
+  assert.equal(response.headers.get('cdn-cache-control'), null);
+  assert.equal(response.headers.get('cloudflare-cdn-cache-control'), null);
+  assert.equal(response.headers.get('x-dshfind-cache-policy'), 'bypass');
+}
+
+test('exports the route and response policies', () => {
+  assert.equal(typeof policy.cacheTtl, 'function');
+  assert.equal(typeof policy.applyPageCachePolicy, 'function');
+});
+
+test('all phase explicitly allows public routes with their TTLs', () => {
+  for (const locale of ['en', 'zh', 'ja', 'ko']) {
+    for (const suffix of ['', '/plugins', '/plugins/browse', '/plugins/all/1', '/plugins/all/123', '/plugins/c/tools', '/plugins/t/test', '/plugins/lang/rust', '/plugins/owner/repo', '/docs', '/docs/start/install', '/learn', '/learn/guide']) {
+      assert.equal(policy.cacheTtl(`/${locale}${suffix}`), 3600, suffix);
+    }
+    for (const suffix of ['/bbs', '/bbs/t/some-thread']) assert.equal(policy.cacheTtl(`/${locale}${suffix}`), 60);
+  }
+  assert.equal(policy.cacheTtl('/api/plugins-data'), 1800);
+  assert.equal(policy.cacheTtl('/sitemap.xml'), 3600);
+  assert.equal(policy.cacheTtl('/sitemap/0.xml'), 3600);
+});
+
+test('unknown and private paths are denied including malformed reserved plugin paths', () => {
+  for (const path of ['/', '/en/login', '/en/search', '/en/bbs/new', '/en/bbs/t', '/en/bbs/t/a/b', '/api/auth', '/api/internal/jobs', '/api/other', '/fr/plugins', '/en/unknown', '/en/plugins/all/foo', '/en/plugins/all/0', '/en/plugins/all/-1', '/en/plugins/all/1.2', '/en/plugins/c', '/en/plugins/t', '/en/plugins/lang', '/en/plugins/c/a/b', '/en/plugins/a/b/c', '/sitemap/a/b', '/sitemap/']) {
+    assert.equal(policy.cacheTtl(path), 0, path);
+    bypass(apply(path));
+  }
+});
+
+test('canary caches exactly the three selected pages and unknown phases fail closed', () => {
+  for (const path of [page, '/en/plugins/fuzz1og/dsh-ocgo-quota', '/zh/plugins/fuzz1og/dsh-ocgo-quota']) assert.equal(policy.cacheTtl(path, 'canary'), 3600);
+  for (const path of ['/ja/plugins/fuzz1og/dsh-ocgo-quota', '/en/plugins', '/api/plugins-data', '/sitemap.xml', `${page}/`]) {
+    assert.equal(policy.cacheTtl(path, 'canary'), 0);
+    bypass(apply(path, {}, {}, { NATIVE_PAGE_CACHE_PHASE: 'canary' }));
+  }
+  bypass(apply(page, {}, {}, { NATIVE_PAGE_CACHE_PHASE: 'disabled' }));
+});
+
+test('public responses preserve body, status and existing Vary while adding request segregation', async () => {
+  const response = apply(page, {}, { headers: { vary: 'Accept-Encoding, rSc', 'cf-cache-status': 'MISS' } });
+  assert.equal(response.headers.get('cache-control'), 'public, max-age=0, s-maxage=3600, stale-while-revalidate=60');
+  assert.equal(response.headers.get('x-dshfind-cache-policy'), 'public-3600');
+  assert.equal(response.headers.get('cf-cache-status'), 'MISS');
+  const vary = response.headers.get('vary').toLowerCase().split(',').map(value => value.trim());
+  for (const field of ['accept-encoding', ...requiredVary]) assert.ok(vary.includes(field), field);
+  assert.equal(vary.filter(value => value === 'rsc').length, 1);
+  assert.equal(response.status, 200);
+  assert.equal(await response.text(), 'payload');
+});
+
+test('RSC and HEAD responses may cache with Vary segregation', () => {
+  for (const requestInit of [{ method: 'HEAD' }, { headers: { RSC: '1', 'Next-Router-State-Tree': 'tree' } }]) {
+    const response = apply(page, requestInit, { headers: { 'content-type': 'text/x-component' } });
+    assert.equal(response.headers.get('x-dshfind-cache-policy'), 'public-3600');
+    for (const field of requiredVary) assert.ok(response.headers.get('vary').toLowerCase().includes(field));
+  }
+});
+
+test('sensitive requests, auth gate and response cookies bypass and clear CDN overrides', () => {
+  const headers = { 'cdn-cache-control': 'public, max-age=9999', 'cloudflare-cdn-cache-control': 'public, max-age=9999' };
+  for (const name of ['Cookie', 'Authorization', 'Next-Action']) {
+    for (const value of ['', 'present']) bypass(apply(page, { headers: { [name]: value } }, { headers }));
+  }
+  for (const method of ['POST', 'PUT', 'DELETE', 'OPTIONS', 'PATCH']) bypass(apply(page, { method }, { headers }));
+  bypass(apply(page, {}, { headers: { ...headers, 'set-cookie': 'session=abc' } }));
+  bypass(apply(page, {}, { headers }, { AUTH_GATE: '1' }));
+  bypass(apply(page, {}, { headers: { ...headers, vary: 'Accept-Encoding, *' } }));
+});
+
+test('only successful responses and route-appropriate content types cache', () => {
+  for (const status of [201, 206, 301, 302, 307, 400, 404, 500]) bypass(apply(page, {}, { status }));
+  for (const type of ['application/json', 'image/png', 'text/css', 'application/javascript', '']) bypass(apply(page, {}, { headers: { 'content-type': type } }));
+  for (const [path, type, ttl] of [['/api/plugins-data', 'application/json; charset=utf-8', 1800], ['/sitemap.xml', 'application/xml', 3600], ['/sitemap/0.xml', 'text/xml; charset=utf-8', 3600]]) {
+    const response = apply(path, {}, { headers: { 'content-type': type } });
+    assert.equal(response.headers.get('x-dshfind-cache-policy'), `public-${ttl}`);
+    for (const field of requiredVary) assert.ok(response.headers.get('vary').toLowerCase().includes(field));
+    bypass(apply(path));
+  }
+});
+
+test('one valid locale preference cookie can cache explicit locale pages with Cookie variation', () => {
+  for (const locale of ['zh', 'en', 'ja', 'ko']) {
+    for (const cookie of [`NEXT_LOCALE=${locale}`, ` \tNEXT_LOCALE=${locale}\t `]) {
+      const response = apply(page, { headers: { cookie } });
+      assert.equal(response.headers.get('x-dshfind-cache-policy'), 'public-3600', cookie);
+      assert.ok(response.headers.get('vary').toLowerCase().split(',').map(value => value.trim()).includes('cookie'));
+    }
+  }
+});
+
+test('other, malformed and duplicate cookies remain private', () => {
+  for (const cookie of ['NEXT_LOCALE=fr', 'NEXT_LOCALE=EN', 'next_locale=en', 'NEXT_LOCALE="en"', 'NEXT_LOCALE=%65n', 'NEXT_LOCALE =en', 'NEXT_LOCALE= en', 'NEXT_LOCALE=en;', ';NEXT_LOCALE=en', 'NEXT_LOCALE=en; NEXT_LOCALE=en', 'NEXT_LOCALE=en, NEXT_LOCALE=en', 'NEXT_LOCALE=en; dshfind_session=secret', 'dshfind_session=secret; NEXT_LOCALE=en', 'NEXT_LOCALE=en; analytics=1']) {
+    bypass(apply(page, { headers: { cookie } }));
+  }
+  const headers = { cookie: 'NEXT_LOCALE=en' };
+  bypass(apply(page, { headers }, {}, { AUTH_GATE: '1' }));
+  bypass(apply(page, { headers: { ...headers, Authorization: 'token' } }));
+  bypass(apply(page, { headers }, { headers: { 'set-cookie': 'NEXT_LOCALE=en' } }));
+  for (const [path, type] of [['/api/plugins-data', 'application/json'], ['/sitemap.xml', 'application/xml']]) {
+    bypass(apply(path, { headers }, { headers: { 'content-type': type } }));
+  }
+});
+
+test('known public SVG and suggestion APIs preserve their own cache lifetimes', () => {
+  for (const path of ['/api/badge/owner/repo', '/api/card/owner/repo', '/api/suggest']) {
+    const type = path === '/api/suggest' ? 'application/json' : 'image/svg+xml; charset=utf-8';
+    for (const control of ['public, max-age=60, s-maxage=300', 'public, max-age=300, s-maxage=3600, stale-while-revalidate=86400']) {
+      for (const method of ['GET', 'HEAD']) {
+        const response = apply(path, { method }, { headers: { 'content-type': type, 'cache-control': control, vary: 'Accept-Encoding' } });
+        assert.equal(response.headers.get('cache-control'), control);
+        for (const field of requiredVary) assert.ok(response.headers.get('vary').toLowerCase().includes(field));
+      }
+    }
+  }
+  const response = apply('/api/suggest', {}, { headers: { 'content-type': 'application/json', 'cache-control': 'no-store' } });
+  assert.equal(response.headers.get('cache-control'), 'no-store');
+  assert.equal(response.headers.get('x-dshfind-cache-policy'), 'bypass');
+});
+
+test('API passthrough never caches sensitive, malformed, unknown or canary responses', () => {
+  for (const path of ['/api/badge/owner/repo', '/api/card/owner/repo', '/api/suggest']) {
+    const headers = { 'content-type': path === '/api/suggest' ? 'application/json' : 'image/svg+xml', 'cache-control': 'public, s-maxage=3600' };
+    for (const requestHeaders of [{ cookie: 'NEXT_LOCALE=en' }, { cookie: 'dshfind_session=secret' }, { Authorization: 'token' }, { 'Next-Action': 'action' }]) bypass(apply(path, { headers: requestHeaders }, { headers }));
+    bypass(apply(path, { method: 'POST' }, { headers }));
+    bypass(apply(path, {}, { status: 404, headers }));
+    bypass(apply(path, {}, { headers: { ...headers, 'set-cookie': 'session=1' } }));
+    bypass(apply(path, {}, { headers: { ...headers, vary: '*' } }));
+    bypass(apply(path, {}, { headers: { ...headers, 'content-type': 'text/html' } }));
+    bypass(apply(path, {}, { headers: { ...headers, 'cache-control': 'private, max-age=60' } }));
+    bypass(apply(path, {}, { headers }, { AUTH_GATE: '1' }));
+    bypass(apply(path, {}, { headers }, { NATIVE_PAGE_CACHE_PHASE: 'canary' }));
+  }
+  for (const path of ['/api/unknown', '/api/suggest/extra', '/api/badge/a', '/api/card/a/b/c']) {
+    bypass(apply(path, {}, { headers: { 'content-type': 'image/svg+xml', 'cache-control': 'public, s-maxage=3600' } }));
+  }
+});

--- a/src/app/[locale]/[...rest]/page.tsx
+++ b/src/app/[locale]/[...rest]/page.tsx
@@ -9,14 +9,8 @@ import { setRequestLocale } from "next-intl/server";
  * 现在无语言前缀的路径由 middleware 重定向到 /zh/...，再由这里落进
  * [locale]/not-found.tsx（自带站点头尾与多语言文案）。
  */
-/**
- * 空数组 = 不预渲染任何路径，但让路由进入 SSG+fallback 模式：
- * 404 结果按 URL 进 ISR 缓存，机器人反复探测同一路径时命中缓存，
- * 不再每次都跑一遍函数渲染。
- */
-export function generateStaticParams(): { rest: string[] }[] {
-  return [];
-}
+// 无效 URL 不进入持久缓存，避免扫描流量扩大存储。
+export const revalidate = 0;
 
 export default async function CatchAllPage({
   params,

--- a/src/app/[locale]/bbs/page.tsx
+++ b/src/app/[locale]/bbs/page.tsx
@@ -6,15 +6,8 @@ import { threadPageFromBackend } from "@/lib/backend";
 import { isLocale } from "@/i18n/config";
 import { pageAlternates } from "@/lib/site";
 
-/**
- * 总板块聚合页。
- *
- * 设计文档原本把这页定为"纯客户端拉取的静态壳"，实施时改成了 ISR + 服务端
- * 首屏：BBS 现在要承载 SEO 文章，纯客户端列表意味着爬虫看不到任何指向帖子页
- * 的 <a>，帖子只能靠 sitemap 被发现，站内权重一点传不过去。5 分钟一次重验证，
- * 每种语言各一份缓存，成本可以忽略。
- */
-export const revalidate = 300;
+/** SSR 首屏保留帖子内链；公开响应边缘缓存 60 秒。 */
+export const revalidate = 0;
 
 export async function generateMetadata({
   params,
@@ -40,7 +33,7 @@ export default async function BbsPage({
   setRequestLocale(locale);
 
   // 后端不可用时给 null，浏览器挂载后会自己再拉一次。
-  const initial = await threadPageFromBackend({ locale }, revalidate);
+  const initial = await threadPageFromBackend({ locale });
 
   return <BbsBrowser initial={initial} />;
 }

--- a/src/app/[locale]/bbs/t/[slug]/page.tsx
+++ b/src/app/[locale]/bbs/t/[slug]/page.tsx
@@ -13,31 +13,13 @@ import { localeUrl } from "@/lib/site";
 
 type Params = Promise<{ locale: string; slug: string }>;
 
-/**
- * 帖子页 —— BBS 的 SEO 主战场，正文必须在服务端 HTML 里。
- *
- * 设计文档原方案是"长 revalidate + Go 发帖后回调 /api/revalidate 按需刷新"。
- * 迁到 Cloudflare Workers 之后这条路走不通：OpenNext 的按需失效要挂 tagCache
- * （见 open-next.config.ts 的注释——全站只用时间型 revalidate，没装），
- * revalidatePath 在 Workers 上不会真的清掉 R2 里的产物。
- * 于是改成 10 分钟的时间型 ISR：爬虫拿到的最多滞后 10 分钟，真人看到的回复
- * 由 <ThreadConversation> 挂载后直连 Go 刷新，两边都不吃亏，也不用多养一套 D1。
- */
-export const revalidate = 600;
-
-/**
- * 空数组 = 构建期一个帖子页都不预渲染，全部首次访问时按需生成后进 ISR 缓存。
- * 这个导出不能省：没有它，这条动态路由会被当成纯动态、每次请求都跑函数
- * （Next 文档 generate-static-params.md 明确要求返回空数组才能运行时 ISR）。
- */
-export function generateStaticParams() {
-  return [];
-}
+/** SSR 保留可索引正文，公开响应边缘缓存 60 秒，客户端继续刷新回复。 */
+export const revalidate = 0;
 
 export async function generateMetadata({ params }: { params: Params }): Promise<Metadata> {
   const { locale, slug } = await params;
   const t = await getTranslations({ locale, namespace: "Meta" });
-  const thread = await threadFromBackend(slug, revalidate);
+  const thread = await threadFromBackend(slug);
   if (!thread) return { title: t("notFoundTitle"), robots: { index: false } };
 
   const description = plainExcerpt(thread.body_md) || thread.title;
@@ -68,7 +50,7 @@ export default async function ThreadPage({ params }: { params: Params }) {
   const { locale, slug } = await params;
   setRequestLocale(locale);
 
-  const thread = await threadFromBackend(slug, revalidate);
+  const thread = await threadFromBackend(slug);
   if (!thread) notFound();
 
   const t = await getTranslations({ locale, namespace: "Bbs" });

--- a/src/app/[locale]/docs/[section]/[[...slug]]/page.tsx
+++ b/src/app/[locale]/docs/[section]/[[...slug]]/page.tsx
@@ -19,19 +19,8 @@ import { breadcrumbJsonLd } from "@/lib/structured-data";
 
 type Params = Promise<{ locale: string; section: string; slug?: string[] }>;
 
-/**
- * 正文在 Turso，改一篇译文不必重新部署——ISR 重验证时自然拿到新内容。
- * 24 小时与插件详情页同一口径。
- */
-export const revalidate = 86400;
-
-/**
- * 不预渲染具体文档：路径来自数据库，构建期查一次 DB 只为拿到几十个 slug，
- * 却会把整份语料塞进构建。首次访问按需渲染后进 ISR 缓存，之后都是静态命中。
- */
-export function generateStaticParams(): { section: string; slug?: string[] }[] {
-  return [];
-}
+/** 文档正文从 D1 读取，公开响应由 Workers Cache 短暂复用。 */
+export const revalidate = 0;
 
 /** slug 段还原成库里的 slug：空数组（板块根）对应 "index"。 */
 function toSlug(parts: string[] | undefined): string {

--- a/src/app/[locale]/docs/page.tsx
+++ b/src/app/[locale]/docs/page.tsx
@@ -11,7 +11,8 @@ import { jsonLdSafe } from "@/lib/json-ld";
 import { pageAlternates } from "@/lib/site";
 import { breadcrumbJsonLd } from "@/lib/structured-data";
 
-export const revalidate = 86400;
+/** 父布局预生成全部语言；文档导航快照随部署更新。 */
+export const dynamicParams = false;
 
 export async function generateMetadata({
   params,
@@ -42,8 +43,8 @@ export default async function DocsIndexPage({
 
   const t = await getTranslations("Docs");
   const loc = locale as Locale;
-  // 用构建期快照而不是查库：本页是预渲染的（revalidate 86400），而 CF 构建机
-  // 拿不到 Worker 的运行时 secret，构建期查库会把这一页烤成空壳，最长空 24 小时。
+  // 用构建期快照预渲染，避免依赖构建机拿不到的 Worker 运行时 secret。
+  // 文档导航变更需刷新快照并重新部署。
   const nav = docNavFor(locale);
 
   const crumbs = [

--- a/src/app/[locale]/plugins/[owner]/[repo]/page.tsx
+++ b/src/app/[locale]/plugins/[owner]/[repo]/page.tsx
@@ -30,7 +30,6 @@ import {
 import { getPluginDetail } from "@/lib/plugins-db";
 import { renamedTo } from "@/lib/plugin-renames";
 import { downloadTier, formatDownloads } from "@/lib/downloads";
-import { realPlugins } from "@/lib/plugins-real";
 import { isLocale, type Locale } from "@/i18n/config";
 import { pageAlternates, SITE_URL } from "@/lib/site";
 import { ShareCardBox } from "@/components/share-card-box";
@@ -39,26 +38,8 @@ import { PluginDiscussion } from "@/components/plugin-discussion";
 
 type Params = Promise<{ locale: string; owner: string; repo: string }>;
 
-/**
- * ISR：详情页按需渲染后静态缓存 24 小时，命中缓存不再产生函数调用。
- * sitemap 对外列了 5600+ 插件 × 4 语言 ≈ 2.3 万个 URL，爬虫会全量抓——
- * 之前每次抓取都是一次动态渲染 + 3 条 Turso 查询。
- * 24h 而不是更短：数据本来就一天一同步（同步会触发部署、重置全部缓存），
- * 6h 只会让爬虫一天把 2.3 万页多烤三遍（CPU/FOT/ISR Writes 三头计费）。
- */
-export const revalidate = 86400;
-
-/**
- * 只预渲染头部插件（realPlugins 行序 featured 优先、star 降序），
- * 其余 2 万多个 URL 首次访问时按需渲染，随后进 ISR 缓存。
- * 没有这个导出，经典模型会把整条路由当成纯动态、每请求都跑函数。
- */
-export function generateStaticParams() {
-  return realPlugins.slice(0, 24).map((p) => {
-    const [owner, repo] = p.fullName.split("/");
-    return { owner, repo };
-  });
-}
+/** Public details render on native cache misses; no persistent ISR writes. */
+export const revalidate = 0;
 
 function day(iso: string) {
   return iso ? iso.slice(0, 10) : "-";
@@ -74,7 +55,7 @@ const SCORED_AT_MAX_AGE_DAYS = 3;
  *
  * 注意这里显示的日期在超过 3 天时与真实评分时间不符——真实时间仍以
  * 库里的 scored_at 为准（API 和评分脚本都读原值，不受这里影响）。
- * 另外详情页是 24h ISR，缓存命中期间不会重算，实际可能显示到 4 天前。
+ * 公开页面由边缘缓存短暂复用，命中期间不会重算日期。
  */
 function displayScoredAt(iso: string) {
   const floor = new Date(Date.now() - SCORED_AT_MAX_AGE_DAYS * 86_400_000);

--- a/src/app/[locale]/plugins/all/[page]/page.tsx
+++ b/src/app/[locale]/plugins/all/[page]/page.tsx
@@ -11,7 +11,8 @@ import { breadcrumbJsonLd, itemListJsonLd } from "@/lib/structured-data";
 
 type Params = Promise<{ locale: string; page: string }>;
 
-export const revalidate = 86400;
+/** 快照分页随部署更新；全部有效页码在构建时生成，越界直接返回 404。 */
+export const dynamicParams = false;
 
 /**
  * 全量分页索引：唯一保证「每个插件详情页都有站内链接指进去」的机制。

--- a/src/app/[locale]/plugins/browse/page.tsx
+++ b/src/app/[locale]/plugins/browse/page.tsx
@@ -16,7 +16,8 @@ import {
 import { pageAlternates } from "@/lib/site";
 import { breadcrumbJsonLd } from "@/lib/structured-data";
 
-export const revalidate = 86400;
+/** 父布局预生成全部语言；索引使用构建期快照，随部署更新。 */
+export const dynamicParams = false;
 
 /**
  * 聚合页总索引。

--- a/src/app/[locale]/plugins/c/[category]/page.tsx
+++ b/src/app/[locale]/plugins/c/[category]/page.tsx
@@ -12,13 +12,10 @@ import { breadcrumbJsonLd, itemListJsonLd } from "@/lib/structured-data";
 
 type Params = Promise<{ locale: string; category: string }>;
 
-/**
- * 数据全部来自构建期快照 realPlugins，内容只在部署时变化，
- * 所以 revalidate 取和详情页一致的 24 小时即可——纯粹是给按需渲染的页面兜底。
- */
-export const revalidate = 86400;
+/** 构建期快照覆盖全部有效分类；内容随部署更新，未生成的分类返回 404。 */
+export const dynamicParams = false;
 
-/** 分类只有 9 个，全部预渲染，运行时不会有函数调用。 */
+/** 与 categoryHub 使用同一份快照，父布局生成全部语言。 */
 export function generateStaticParams() {
   return listCategories().map((c) => ({ category: c.slug }));
 }

--- a/src/app/[locale]/plugins/lang/[language]/page.tsx
+++ b/src/app/[locale]/plugins/lang/[language]/page.tsx
@@ -12,7 +12,8 @@ import { breadcrumbJsonLd, itemListJsonLd } from "@/lib/structured-data";
 
 type Params = Promise<{ locale: string; language: string }>;
 
-export const revalidate = 86400;
+/** 构建期快照随部署更新；阈值内的有效语言全部预渲染，不做按需补页。 */
+export const dynamicParams = false;
 
 /** 语言 facet 只有十几个（阈值 MIN_LANGUAGE_PLUGINS），全部预渲染。 */
 export function generateStaticParams() {

--- a/src/app/[locale]/plugins/page.tsx
+++ b/src/app/[locale]/plugins/page.tsx
@@ -13,14 +13,8 @@ import { pageAlternates } from "@/lib/site";
 /** 目录页 facet 导航里露出的热门标签数；其余标签走 /plugins/browse。 */
 const TOP_TAGS = 40;
 
-/**
- * ISR：整页（含 Turso 查询结果）静态缓存 30 分钟。
- * 之前 await searchParams 让本页每个请求都动态渲染——5646 个插件的
- * props 序列化成几 MB 的 RSC 载荷，每次访问都从源站重新传一遍，
- * 是 Fast Origin Transfer / Fluid CPU 账单的最大单项。
- * ?category= 深链改由 PluginsBrowser 在客户端读 location.search。
- */
-export const revalidate = 1800;
+/** 首屏保留 SSR；公开响应由 Workers Cache 复用，不写入 R2。 */
+export const revalidate = 0;
 
 /**
  * 首屏直出的插件数（行序 featured 优先、star 降序，前 100 覆盖默认视图首屏）。

--- a/src/app/[locale]/plugins/t/[tag]/page.tsx
+++ b/src/app/[locale]/plugins/t/[tag]/page.tsx
@@ -12,21 +12,12 @@ import { breadcrumbJsonLd, itemListJsonLd } from "@/lib/structured-data";
 
 type Params = Promise<{ locale: string; tag: string }>;
 
-export const revalidate = 86400;
+// 标签按需渲染，公开响应由边缘缓存复用，长尾标签也无需持久化。
+export const revalidate = 0;
 
 /** facet 导航里露出的标签数——272 个全列出来会让每页多几 KB 且没人扫得完。 */
 const NAV_TAGS = 60;
 
-/**
- * 只预渲染热门标签，其余按需渲染后进 ISR 缓存。
- * 与详情页同一取舍：标签 hub 有 272 个 × 4 语言 ≈ 1,100 页，
- * 全量预渲染会显著拉长 CF 构建（那边已经有过构建超时回滚的前科）。
- */
-export function generateStaticParams() {
-  return listTags()
-    .slice(0, NAV_TAGS)
-    .map((t) => ({ tag: t.slug }));
-}
 
 export async function generateMetadata({
   params,

--- a/src/app/api/plugins-data/route.ts
+++ b/src/app/api/plugins-data/route.ts
@@ -7,10 +7,9 @@ import { getPluginsPageData } from "@/lib/plugins-db";
  *
  * /plugins 页首屏只直出前 100 个插件（HTML 从 3.6MB 降到约 0.2MB），
  * 其余由 PluginsBrowser 在浏览器空闲时从这里拉取。
- * revalidate 让本路由进 ISR 缓存：命中缓存直接由 CDN 吐 JSON，
- * 不产生函数调用；数据新鲜度与 /plugins 页一致（30 分钟）。
+ * Workers Cache 复用公开 JSON 30 分钟；缓存未命中才查库。
  */
-export const revalidate = 1800;
+export const revalidate = 0;
 
 export async function GET() {
   const { plugins, i18nDescriptions } = await getPluginsPageData();

--- a/src/app/sitemap.xml/route.ts
+++ b/src/app/sitemap.xml/route.ts
@@ -10,10 +10,10 @@ import {
  * 用手写 route handler 而不是 Next 的 `sitemap.ts` + `generateSitemaps()`，
  * 正是因为后者只产分片、不产索引，还会让这个 URL 消失。
  *
- * 每小时重验证：threads 分片本身每小时刷新，索引里的 lastmod 得跟着动，
+ * 边缘缓存一小时：threads 分片本身每小时刷新，索引里的 lastmod 得跟着动，
  * 否则 Google 看到 lastmod 没变就不会回头抓那个分片。
  */
-export const revalidate = 3600;
+export const revalidate = 0;
 
 export function GET() {
   return new Response(renderSitemapIndex(new Date().toISOString()), {

--- a/src/app/sitemap/[shard]/route.ts
+++ b/src/app/sitemap/[shard]/route.ts
@@ -1,28 +1,11 @@
 import {
   buildShard,
   renderUrlset,
-  shardIds,
   XML_HEADERS,
 } from "@/lib/sitemap-shards";
 
-/**
- * `/sitemap/<id>.xml` —— 各个分片。
- *
- * 全部预渲染：分片是爬虫的入口，按需渲染意味着 Googlebot 第一次来就得等
- * 函数冷启动跑完几千条 URL 的拼装。
- *
- * threads 分片需要每小时刷新，其余数据都来自构建期快照、只在部署时变化——
- * 但 route segment config 只能是常量，所以统一取 3600；对静态分片而言
- * 重验证只是重新拼一次同样的字符串，成本可以忽略。
- */
-export const revalidate = 3600;
-
-/** 未列出的 id 一律 404，不给爬虫留下无限的探测面。 */
-export const dynamicParams = false;
-
-export function generateStaticParams() {
-  return shardIds().map((id) => ({ shard: `${id}.xml` }));
-}
+/** 分片按需生成并由 Workers Cache 复用；不再持久化 ISR 产物。 */
+export const revalidate = 0;
 
 export async function GET(
   _req: Request,

--- a/src/lib/backend.ts
+++ b/src/lib/backend.ts
@@ -57,17 +57,12 @@ export async function suggestFromBackend(q: string): Promise<Suggestion[] | null
   }
 }
 
-/**
- * BBS 的服务端取数（docs/bbs-design.md Phase 2）。与上面两个函数不同，
- * 这里用 next.revalidate 而不是 no-store：帖子页与聚合页都是 ISR 静态页，
- * 一个 no-store 的 fetch 会把整条路由拽回每请求动态渲染——正是全站静态化
- * 要避免的那件事（见 plugins/page.tsx 顶部注释）。
- */
-async function forumGET<T>(path: string, revalidate: number): Promise<T | null> {
+/** BBS 在页面缓存未命中时取实时数据，不再写入 Next 持久 fetch 缓存。 */
+async function forumGET<T>(path: string): Promise<T | null> {
   if (!API_BASE) return null;
   try {
     const res = await fetch(`${API_BASE}${path}`, {
-      next: { revalidate },
+      cache: "no-store",
       headers: backendHeaders("dshfind-next/bbs"),
     });
     if (!res.ok) return null;
@@ -79,32 +74,29 @@ async function forumGET<T>(path: string, revalidate: number): Promise<T | null> 
 
 /** null = 后端不可用；调用方渲染空壳，浏览器侧会再拉一次。 */
 export function threadPageFromBackend(
-  params: { board?: string; locale?: string; page?: number; perPage?: number },
-  revalidate: number
+  params: { board?: string; locale?: string; page?: number; perPage?: number }
 ): Promise<ThreadPage | null> {
   const query = new URLSearchParams();
   if (params.board) query.set("board", params.board);
   if (params.locale) query.set("locale", params.locale);
   if (params.page && params.page > 1) query.set("page", String(params.page));
   if (params.perPage) query.set("per_page", String(params.perPage));
-  return forumGET<ThreadPage>(`/v1/forum/threads?${query}`, revalidate);
+  return forumGET<ThreadPage>(`/v1/forum/threads?${query}`);
 }
 
 /**
  * null = 帖子确实不存在（调用方 notFound()）；后端不可用则抛错。
  *
- * 这个区分是必须的：帖子页是 ISR，把一次后端抖动渲染成 404 会让这个 URL 在
- * 整个 revalidate 窗口里对爬虫回 404。抛错则不会写进缓存，下次请求重试。
+ * 后端抖动不能伪装成 404；错误响应不进入边缘缓存，下次请求可重试。
  */
 export async function threadFromBackend(
-  slug: string,
-  revalidate: number
+  slug: string
 ): Promise<Thread | null> {
   // 本地开发没配后端时不抛错，直接当作没有这个帖子。
   if (!API_BASE) return null;
   const res = await fetch(
     `${API_BASE}/v1/forum/threads/${encodeURIComponent(slug)}`,
-    { next: { revalidate }, headers: backendHeaders("dshfind-next/bbs") }
+    { cache: "no-store", headers: backendHeaders("dshfind-next/bbs") }
   );
   if (res.status === 404) return null;
   if (!res.ok) {

--- a/src/lib/sitemap-shards.ts
+++ b/src/lib/sitemap-shards.ts
@@ -290,12 +290,12 @@ async function buildDocs(): Promise<SitemapEntry[]> {
 
 async function buildThreads(): Promise<SitemapEntry[]> {
   // 后端不可用时 threadPageFromBackend 回 null——分片少几个 URL 也比整份
-  // 构建失败强，下一小时的重验证会补上。
+  // 构建失败强，下一次边缘缓存刷新会补上。
   // 插件讨论帖排除在外：正文是空的、标题只是仓库名，帖子页本身也 noindex。
   //
   // 与其他条目不同，帖子只登记它自己那个语言的 URL：一篇中文帖在 /en /ja /ko
   // 下渲染的是同一份正文，四条都收录就是自造重复内容。
-  const threads = await threadPageFromBackend({ perPage: THREAD_LIMIT }, 3600);
+  const threads = await threadPageFromBackend({ perPage: THREAD_LIMIT });
   const out: SitemapEntry[] = [];
   for (const thread of threads?.items ?? []) {
     if (thread.plugin_full_name) continue;

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -10,6 +10,15 @@ const intlMiddleware = createMiddleware({
   localePrefix: "always",
 });
 
+// Explicit language URLs are self-contained and must not set preference cookies
+// on public cacheable responses. Root redirects still honor saved preferences.
+const prefixedIntlMiddleware = createMiddleware({
+  locales,
+  defaultLocale,
+  localePrefix: "always",
+  localeCookie: false,
+});
+
 function getLocaleFromPath(pathname: string): string {
   const first = pathname.split("/")[1];
   return (locales as readonly string[]).includes(first)
@@ -39,7 +48,9 @@ export async function middleware(request: NextRequest) {
   }
 
   // 语言路由处理（含 / → 默认语言重定向、前缀校验）
-  return intlMiddleware(request);
+  return /^\/(zh|en|ja|ko)(\/|$)/.test(request.nextUrl.pathname)
+    ? prefixedIntlMiddleware(request)
+    : intlMiddleware(request);
 }
 
 export const config = {

--- a/wrangler.canary.jsonc
+++ b/wrangler.canary.jsonc
@@ -1,0 +1,18 @@
+{
+  "$schema": "node_modules/wrangler/config-schema.json",
+  "name": "dshfind-cache-canary",
+  "main": "custom-worker.mjs",
+  "account_id": "8f19bebe359e4ec1a24c68c5f49c1584",
+  "compatibility_date": "2025-09-01",
+  "compatibility_flags": ["nodejs_compat", "global_fetch_strictly_public"],
+  "workers_dev": true,
+  "preview_urls": true,
+  "cache": { "enabled": true, "cross_version_cache": false },
+  "vars": { "NATIVE_PAGE_CACHE_PHASE": "all", "NATIVE_CACHE_DIAGNOSTICS": "1" },
+  "assets": { "directory": ".open-next/assets", "binding": "ASSETS" },
+  "d1_databases": [{ "binding": "DB", "database_name": "dshfind",
+    "database_id": "47f4c8d2-a9d7-41c3-b142-f8693b20a89d" }],
+  "services": [{ "binding": "WORKER_SELF_REFERENCE", "service": "dshfind-cache-canary" }],
+  "migrations": [{ "tag": "v1", "new_sqlite_classes": ["DOQueueHandler"] }],
+  "observability": { "enabled": true, "head_sampling_rate": 1 }
+}

--- a/wrangler.jsonc
+++ b/wrangler.jsonc
@@ -1,22 +1,22 @@
 {
   "$schema": "node_modules/wrangler/config-schema.json",
   "name": "dshfind",
-  // OpenNext 的产物入口。跑 `pnpm cf:build` 才会生成，别手动改 .open-next/。
-  "main": ".open-next/worker.js",
+  // HTTP 缓存策略包装 OpenNext 产物；先运行 pnpm cf:build。
+  "main": "custom-worker.mjs",
   "compatibility_date": "2025-09-01",
   // nodejs_compat：Next server runtime 需要 Node 内置模块的 polyfill。
   // global_fetch_strictly_public：让服务端 fetch("https://api.dshfind.com/...")
   //   真的走公网到 Railway，而不是被 Workers 回环到自己身上。
   "compatibility_flags": ["nodejs_compat", "global_fetch_strictly_public"],
 
-  // 预渲染 HTML、_next/static、public/ 下的文件。命中资源不会调起 Worker。
+  // 预渲染页面放只读资产，公开响应由原生缓存复用；命中无渲染 CPU，但请求仍计费。
   "assets": {
     "directory": ".open-next/assets",
     "binding": "ASSETS"
   },
 
   // 业务数据库（Turso 迁移而来，方案见 docs/d1-migration-plan.md）。
-  // 服务端读路径走 binding；next dev / 构建期无 binding 时 src/lib/db.ts 回退 Turso HTTP。
+  // 服务端读路径走 binding；next dev / 构建期无 binding 时 src/lib/db.ts 回退内部 D1 HTTP 或静态快照。
   "d1_databases": [
     {
       "binding": "DB",
@@ -25,24 +25,11 @@
     }
   ],
 
-  // ISR 增量缓存。/plugins（1800s）与插件详情页（86400s）重验证后的产物落这里。
-  "r2_buckets": [
-    {
-      "binding": "NEXT_INC_CACHE_R2_BUCKET",
-      "bucket_name": "dshfind-isr-cache"
-    }
-  ],
+  // R2 桶与旧对象保留供 48 小时观察/回滚，应用不再绑定或写入。
+  "cache": { "enabled": true, "cross_version_cache": false },
+  "vars": { "NATIVE_PAGE_CACHE_PHASE": "all" },
 
-  // 重验证队列：同一路径过期后只让一个请求回源重建，其余吃 stale。
-  // 站点只用时间型 revalidate（无 revalidateTag/revalidatePath），所以不需要 tag cache。
-  "durable_objects": {
-    "bindings": [
-      {
-        "name": "NEXT_CACHE_DO_QUEUE",
-        "class_name": "DOQueueHandler"
-      }
-    ]
-  },
+  // 保留历史 DO 类迁移供回滚；当前不使用 ISR 队列，不删除既有 DO 数据。
   "migrations": [
     {
       "tag": "v1",
@@ -50,7 +37,7 @@
     }
   ],
 
-  // ISR 重建要能回调自身。service 名必须与上面的 name 一致。
+  // 保留 OpenNext 的自身服务引用；service 名与上面的 name 一致。
   "services": [
     {
       "binding": "WORKER_SELF_REFERENCE",


### PR DESCRIPTION
The current ISR setup writes page artifacts to R2 under each build ID, leaving hundreds of GB of old cache objects. This migration serves build snapshots from read-only Static Assets and uses native Workers Cache for public SSR responses. Database pages no longer persist ISR/fetch artifacts; the application no longer binds R2 or uses the ISR queue. The existing bucket, objects, and DO migration history remain intact for the requested 48-hour observation and rollback.

Cookie/authentication and HTML/RSC/router/host variations are isolated. Private requests and errors bypass shared caching; explicit locale URLs no longer set preference cookies. Existing public badge/card/suggest API cache policies are preserved. Build artifacts are excluded from ESLint so the deployment checks remain usable.

Validation: 124 tests pass, typecheck passes, lint has 0 errors; OpenNext build has 562 pre-rendered routes and zero timed ISR entries. Three-page live pilot passed: warm uncached CPU p95 64 ms (24 requests), cached TTFB p95 254 ms (11 reused-connection requests), RSC and cookie isolation verified. Cold CPU can be much higher (observed max 1639 ms); this is documented separately. Full no-R2 preview passed 29/29 page/API/404 checks. Independent review verified social metadata remains in head on browser-filled cached responses.

Full preview version: 608d7e67-afd2-4e45-ad2f-a1d1b0b53f61. Rollback and 48-hour observation details: docs/native-page-cache.md. No R2 cleanup is part of this PR.
